### PR TITLE
Bunch of fixes

### DIFF
--- a/src/main/java/crazypants/enderio/config/Config.java
+++ b/src/main/java/crazypants/enderio/config/Config.java
@@ -334,6 +334,7 @@ public final class Config {
   public static double killerJoeHooverXpWidth = 5;
   public static double killerJoeHooverXpLength = 10;
   public static int killerJoeMaxXpLevel = Integer.MAX_VALUE;
+  public static boolean killerJoeMustSee = false;
 
   public static boolean allowTileEntitiesAsPaintSource = true;
 
@@ -1004,6 +1005,8 @@ public final class Config {
     killerJoeHooverXpWidth = config.get(sectionKiller.name, "killerJoeHooverXpWidth", killerJoeHooverXpWidth,
         "The distance from which XP will be gathered in front of Joe.").getDouble(killerJoeHooverXpWidth);
     killerJoeMaxXpLevel = config.get(sectionMisc.name, "killerJoeMaxXpLevel", killerJoeMaxXpLevel, "Maximum level of XP the killer joe can contain.").getInt();
+
+    killerJoeMustSee = config.get(sectionKiller.name, "killerJoeMustSee", killerJoeMustSee, "Set whether the Killer Joe can attack through blocks.").getBoolean();
 
     isGasConduitEnabled = config.getString("isGasConduitEnabled", sectionItems.name, isGasConduitEnabled,
         "Can be set to 'auto', 'true' or 'false'. When set to auto the gas conduit will only be enabled when Mekanism is installed.");

--- a/src/main/java/crazypants/enderio/machine/AbstractMachineEntity.java
+++ b/src/main/java/crazypants/enderio/machine/AbstractMachineEntity.java
@@ -428,7 +428,7 @@ public abstract class AbstractMachineEntity extends TileEntityEio implements ISi
   @Override
   public void readCustomNBT(NBTTagCompound nbtRoot) {
 
-    facing = nbtRoot.getShort("facing");
+    setFacing(nbtRoot.getShort("facing"));
     redstoneCheckPassed = nbtRoot.getBoolean("redstoneCheckPassed");
     forceClientUpdate = nbtRoot.getBoolean("forceClientUpdate");
     readCommon(nbtRoot);

--- a/src/main/java/crazypants/enderio/machine/capbank/TileCapBank.java
+++ b/src/main/java/crazypants/enderio/machine/capbank/TileCapBank.java
@@ -507,6 +507,7 @@ public class TileCapBank extends TileEntityEio implements IInternalPowerHandler,
   }
   
   private void validateModeForReceptor(EnergyReceptor er) {
+    if (er == null) return;
     IoMode ioMode = getIoMode(er.getDir());
     if((ioMode == IoMode.PUSH_PULL || ioMode == IoMode.NONE) && er.getConduit() == null) {
       if(er.getReceptor().isOutputOnly()) {

--- a/src/main/java/crazypants/enderio/machine/farm/TileFarmStation.java
+++ b/src/main/java/crazypants/enderio/machine/farm/TileFarmStation.java
@@ -49,7 +49,7 @@ public class TileFarmStation extends AbstractPoweredTaskEntity {
       }
     },
     
-    AXE     { boolean match(ItemStack item) { return item.getItem().getHarvestLevel(item, "axe") > 0;         }},
+    AXE     { boolean match(ItemStack item) { return item.getItem().getHarvestLevel(item, "axe") >= 0;         }},
     TREETAP { boolean match(ItemStack item) { return item.getItem().getClass() == RubberTreeFarmerIC2.treeTap;}};
     
     public final boolean itemMatches(ItemStack item) {

--- a/src/main/java/crazypants/enderio/machine/killera/TileKillerJoe.java
+++ b/src/main/java/crazypants/enderio/machine/killera/TileKillerJoe.java
@@ -6,11 +6,13 @@ import net.minecraft.command.IEntitySelector;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.item.EntityXPOrb;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.ItemSword;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.AxisAlignedBB;
+import net.minecraft.util.Vec3;
 import net.minecraft.world.WorldServer;
 import net.minecraftforge.common.util.FakePlayer;
 import net.minecraftforge.common.util.ForgeDirection;
@@ -45,6 +47,8 @@ public class TileKillerJoe extends AbstractMachineEntity implements IFluidHandle
   private static int IO_MB_TICK = 250;
 
   protected AxisAlignedBB killBounds;
+
+  private int[] frontFaceAndSides;
 
   protected AxisAlignedBB hooverBounds;
 
@@ -164,7 +168,9 @@ public class TileKillerJoe extends AbstractMachineEntity implements IFluidHandle
     if(!entsInBounds.isEmpty()) {
 
       for (EntityLivingBase ent : entsInBounds) {
-        if(!ent.isDead) {
+        if(!ent.isDead && !ent.isEntityInvulnerable()) {
+          if (ent instanceof EntityPlayer && ((EntityPlayer)ent).capabilities.disableDamage) continue;  //Ignore players in creative, can't damage them;
+          if (Config.killerJoeMustSee && !canJoeSee(ent)) continue;
           FakePlayer fakee = getAttackera();
           fakee.setCurrentItemOrArmor(0, getStackInSlot(0));
           fakee.attackTargetEntityWithCurrentItem(ent);
@@ -179,6 +185,25 @@ public class TileKillerJoe extends AbstractMachineEntity implements IFluidHandle
     }
     return false;
   }
+
+  private boolean canJoeSee(EntityLivingBase ent)
+  {
+    Vec3 entPos = Vec3.createVectorHelper(ent.posX, ent.posY + (double)ent.getEyeHeight(), ent.posZ);
+    for (int facing:frontFaceAndSides)
+    {
+      if (this.worldObj.rayTraceBlocks(Vec3.createVectorHelper(this.xCoord + faceMidPoints[facing][0], this.yCoord + +faceMidPoints[facing][1], this.zCoord + +faceMidPoints[facing][2]), entPos) == null) return true;
+    }
+    return false;
+  }
+
+  @Override
+  public void setFacing(short facing)
+  {
+    super.setFacing(facing);
+    frontFaceAndSides = new int[]{this.facing,ForgeDirection.ROTATION_MATRIX[0][this.facing],ForgeDirection.ROTATION_MATRIX[1][this.facing]};
+  }
+
+  private static double[][] faceMidPoints = new double[][]{{0.5D,0.0D,0.5D},{0.5D,1.0D,0.5D},{0.5D,0.5D,0.0D},{0.5D,0.5D,1.0D},{0.0D,0.5D,0.5D},{1.0D,0.5D,0.5D}};
 
   //-------------------------------  XP
 


### PR DESCRIPTION
for #1561, Wood is tool level 0, non-axes are -1, changed match function to reflect that
for  #1560, added line of sight with config to killer joe
added a null check for a crash I got intermittently when placing regular blocks next to a vibrant capacitor