### PR TITLE
ME counduits should now behave better

### DIFF
--- a/src/main/java/crazypants/enderio/conduit/AbstractItemConduit.java
+++ b/src/main/java/crazypants/enderio/conduit/AbstractItemConduit.java
@@ -61,12 +61,10 @@ public abstract class AbstractItemConduit extends Item implements IConduitItem {
           TileEntity te = world.getTileEntity(placeAt.x, placeAt.y, placeAt.z);
           if(te instanceof IConduitBundle) {
             IConduitBundle bundle = (IConduitBundle) te;
-            if(bundle != null) {
-              bundle.addConduit(createConduit(stack));
-              Block b = EnderIO.blockConduitBundle;
-              world.playSoundEffect(x + 0.5F, y + 0.5F, z + 0.5F, b.stepSound.getStepResourcePath(),
-                  (b.stepSound.getVolume() + 1.0F) / 2.0F, b.stepSound.getPitch() * 0.8F);
-            }
+            bundle.addConduit(createConduit(stack, player));
+            Block b = EnderIO.blockConduitBundle;
+            world.playSoundEffect(x + 0.5F, y + 0.5F, z + 0.5F, b.stepSound.getStepResourcePath(),
+                (b.stepSound.getVolume() + 1.0F) / 2.0F, b.stepSound.getPitch() * 0.8F);
           }
         }
       }
@@ -89,7 +87,7 @@ public abstract class AbstractItemConduit extends Item implements IConduitItem {
           System.out.println("AbstractItemConduit.onItemUse: Bundle null");
           return false;
         }
-        IConduit con = createConduit(stack);
+        IConduit con = createConduit(stack, player);
         if(con == null) {
           System.out.println("AbstractItemConduit.onItemUse: Conduit null.");
           return false;

--- a/src/main/java/crazypants/enderio/conduit/BlockConduitBundle.java
+++ b/src/main/java/crazypants/enderio/conduit/BlockConduitBundle.java
@@ -593,7 +593,7 @@ public class BlockConduitBundle extends BlockEio implements IGuiHandler, IFacade
   private boolean handleConduitClick(World world, int x, int y, int z, EntityPlayer player, IConduitBundle bundle, ItemStack stack) {
     IConduitItem equipped = (IConduitItem) stack.getItem();
     if(!bundle.hasType(equipped.getBaseConduitType())) {
-      bundle.addConduit(equipped.createConduit(stack));
+      bundle.addConduit(equipped.createConduit(stack, player));
       if(!player.capabilities.isCreativeMode) {
         world.playSoundEffect(x + 0.5F, y + 0.5F, z + 0.5F, stepSound.getStepResourcePath(),
             (stepSound.getVolume() + 1.0F) / 2.0F, stepSound.getPitch() * 0.8F);

--- a/src/main/java/crazypants/enderio/conduit/ConduitUtil.java
+++ b/src/main/java/crazypants/enderio/conduit/ConduitUtil.java
@@ -124,6 +124,10 @@ public class ConduitUtil {
     if(con.getNetwork() != null) { //this should have been destroyed when destroying the neighbours network but lets just make sure
       con.getNetwork().destroyNetwork();
     }
+    con.connectionsChanged();
+    if(neighbour != null) {
+      neighbour.connectionsChanged();
+    }
   }
 
   public static <T extends IConduit> boolean joinConduits(T con, ForgeDirection faceHit) {
@@ -138,6 +142,8 @@ public class ConduitUtil {
       if(neighbour.getNetwork() != null) {
         neighbour.getNetwork().destroyNetwork();
       }
+      con.connectionsChanged();
+      neighbour.connectionsChanged();
       return true;
     }
     return false;

--- a/src/main/java/crazypants/enderio/conduit/IConduit.java
+++ b/src/main/java/crazypants/enderio/conduit/IConduit.java
@@ -66,6 +66,8 @@ public interface IConduit {
 
   void conduitConnectionRemoved(ForgeDirection fromDirection);
 
+  void connectionsChanged();
+
   AbstractConduitNetwork<?, ?> getNetwork();
 
   boolean setNetwork(AbstractConduitNetwork<?, ?> network);

--- a/src/main/java/crazypants/enderio/conduit/IConduitItem.java
+++ b/src/main/java/crazypants/enderio/conduit/IConduitItem.java
@@ -1,12 +1,13 @@
 package crazypants.enderio.conduit;
 
 import net.minecraft.item.ItemStack;
+import net.minecraft.entity.player.EntityPlayer;
 import crazypants.enderio.api.tool.IHideFacades;
 
 public interface IConduitItem extends IHideFacades {
 
   Class<? extends IConduit> getBaseConduitType();
 
-  IConduit createConduit(ItemStack item);
+  IConduit createConduit(ItemStack item, EntityPlayer player);
 
 }

--- a/src/main/java/crazypants/enderio/conduit/TileConduitBundle.java
+++ b/src/main/java/crazypants/enderio/conduit/TileConduitBundle.java
@@ -6,8 +6,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import com.google.common.collect.Lists;
-
 import mekanism.api.gas.Gas;
 import mekanism.api.gas.GasStack;
 import net.minecraft.block.Block;
@@ -894,8 +892,7 @@ public class TileConduitBundle extends TileEntityEio implements IConduitBundle {
     if (cond == null) {
       return AECableType.NONE;
     } else {
-      ConnectionMode mode = cond.getConnectionMode(dir);
-      return mode == ConnectionMode.DISABLED ? AECableType.NONE : AECableType.SMART;
+      return cond.isConnectedTo(dir) ? AECableType.SMART : AECableType.NONE;
     }
   }
   

--- a/src/main/java/crazypants/enderio/conduit/gas/ItemGasConduit.java
+++ b/src/main/java/crazypants/enderio/conduit/gas/ItemGasConduit.java
@@ -40,7 +40,7 @@ public class ItemGasConduit extends AbstractItemConduit implements IAdvancedTool
   }
 
   @Override
-  public IConduit createConduit(ItemStack stack) {
+  public IConduit createConduit(ItemStack stack, EntityPlayer player) {
     return new GasConduit();
   }
 

--- a/src/main/java/crazypants/enderio/conduit/item/ItemItemConduit.java
+++ b/src/main/java/crazypants/enderio/conduit/item/ItemItemConduit.java
@@ -33,7 +33,7 @@ public class ItemItemConduit extends AbstractItemConduit {
   }
 
   @Override
-  public IConduit createConduit(ItemStack item) {
+  public IConduit createConduit(ItemStack item, EntityPlayer player) {
     return new ItemConduit(item.getItemDamage());
   }
 

--- a/src/main/java/crazypants/enderio/conduit/liquid/ItemLiquidConduit.java
+++ b/src/main/java/crazypants/enderio/conduit/liquid/ItemLiquidConduit.java
@@ -40,7 +40,7 @@ public class ItemLiquidConduit extends AbstractItemConduit implements IAdvancedT
   }
 
   @Override
-  public IConduit createConduit(ItemStack stack) {
+  public IConduit createConduit(ItemStack stack, EntityPlayer player) {
     if(stack.getItemDamage() == 1) {
       return new AdvancedLiquidConduit();
     } else if(stack.getItemDamage() == 2) {

--- a/src/main/java/crazypants/enderio/conduit/liquid/LiquidConduit.java
+++ b/src/main/java/crazypants/enderio/conduit/liquid/LiquidConduit.java
@@ -341,7 +341,7 @@ public class LiquidConduit extends AbstractTankConduit {
   // -----------------------------
 
   @Override
-  protected void connectionsChanged() {
+  public void connectionsChanged() {
     super.connectionsChanged();
     updateTank();
   }

--- a/src/main/java/crazypants/enderio/conduit/me/ItemMEConduit.java
+++ b/src/main/java/crazypants/enderio/conduit/me/ItemMEConduit.java
@@ -1,5 +1,6 @@
 package crazypants.enderio.conduit.me;
 
+import appeng.api.AEApi;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import crazypants.enderio.ModObject;
@@ -32,8 +33,10 @@ public class ItemMEConduit extends AbstractItemConduit {
   }
 
   @Override
-  public IConduit createConduit(ItemStack item) {
-    return new MEConduit(item.getItemDamage());
+  public IConduit createConduit(ItemStack item, EntityPlayer player) {
+    MEConduit con = new MEConduit(item.getItemDamage());
+    con.setPlayerID(AEApi.instance().registries().players().getID(player));
+    return con;
   }
   
   @Override

--- a/src/main/java/crazypants/enderio/conduit/power/ItemPowerConduit.java
+++ b/src/main/java/crazypants/enderio/conduit/power/ItemPowerConduit.java
@@ -41,7 +41,7 @@ public class ItemPowerConduit extends AbstractItemConduit {
   }
 
   @Override
-  public IConduit createConduit(ItemStack stack) {
+  public IConduit createConduit(ItemStack stack, EntityPlayer player) {
     return new PowerConduit(stack.getItemDamage());
   }
 

--- a/src/main/java/crazypants/enderio/conduit/redstone/InsulatedRedstoneConduit.java
+++ b/src/main/java/crazypants/enderio/conduit/redstone/InsulatedRedstoneConduit.java
@@ -197,6 +197,8 @@ public class InsulatedRedstoneConduit extends RedstoneConduit implements IInsula
               }
               neighbour.conduitConnectionRemoved(connDir.getOpposite());
               conduitConnectionRemoved(connDir);
+              neighbour.connectionsChanged();
+              connectionsChanged();
               updateNetwork();
               neighbour.updateNetwork();
               return true;

--- a/src/main/java/crazypants/enderio/conduit/redstone/ItemRedstoneConduit.java
+++ b/src/main/java/crazypants/enderio/conduit/redstone/ItemRedstoneConduit.java
@@ -32,7 +32,7 @@ public class ItemRedstoneConduit extends AbstractItemConduit {
   }
 
   @Override
-  public IConduit createConduit(ItemStack stack) {
+  public IConduit createConduit(ItemStack stack, EntityPlayer player) {
     if(stack.getItemDamage() == 0) {
       return new RedstoneConduit();
     }

--- a/src/main/java/crazypants/enderio/machine/capbank/network/CapBankClientNetwork.java
+++ b/src/main/java/crazypants/enderio/machine/capbank/network/CapBankClientNetwork.java
@@ -74,7 +74,7 @@ public class CapBankClientNetwork implements ICapBankNetwork {
     BlockCoord bc = state.getInventoryImplLocation();
     if(bc == null) {
       inventory.setCapBank(null);
-    } else {
+    } else if(world != null) {
       TileEntity te = world.getTileEntity(bc.x, bc.y, bc.z);
       if(te instanceof TileCapBank) {
         inventory.setCapBank((TileCapBank) te);


### PR DESCRIPTION
Reworked the implementation of ME conduits - solves the following issues:
- provides player ID to be compatible with the security stations
- allows connecting and disconnecting of ME conduits using a wrench
- prevents leaking of nodes on chunk unload

Important: requires picking up existing ME conduits and placing them again to get the connections correct