### PR TITLE
add recipe handler to upgrade basic to normal capacitor banks

### DIFF
--- a/src/main/java/crazypants/enderio/machine/MachineRecipes.java
+++ b/src/main/java/crazypants/enderio/machine/MachineRecipes.java
@@ -135,15 +135,17 @@ public class MachineRecipes {
 
     //capacitor bank
 
-    ItemStack capBank = BlockItemCapBank.createItemStackWithPower(CapBankType.getMetaFromType(CapBankType.SIMPLE), 0);
-    GameRegistry.addShapedRecipe(capBank, "bcb", "cmc", "bcb", 'b', Items.iron_ingot, 'c', capacitor, 'm', Blocks.redstone_block);
-    capBank = BlockItemCapBank.createItemStackWithPower(CapBankType.getMetaFromType(CapBankType.ACTIVATED), 0);
-    GameRegistry.addShapedRecipe(capBank, "bcb", "cmc", "bcb", 'b', electricSteel, 'c', capacitor2, 'm', Blocks.redstone_block);
-    capBank = BlockItemCapBank.createItemStackWithPower(CapBankType.getMetaFromType(CapBankType.VIBRANT), 0);
-    GameRegistry.addShapedRecipe(capBank, "bcb", "cmc", "bcb", 'b', electricSteel, 'c', capacitor3, 'm', vibCry);
+    ItemStack capBank1 = BlockItemCapBank.createItemStackWithPower(CapBankType.getMetaFromType(CapBankType.SIMPLE), 0);
+    GameRegistry.addShapedRecipe(capBank1, "bcb", "cmc", "bcb", 'b', Items.iron_ingot, 'c', capacitor, 'm', Blocks.redstone_block);
+    ItemStack capBank2 = BlockItemCapBank.createItemStackWithPower(CapBankType.getMetaFromType(CapBankType.ACTIVATED), 0);
+    GameRegistry.addShapedRecipe(capBank2, "bcb", "cmc", "bcb", 'b', electricSteel, 'c', capacitor2, 'm', Blocks.redstone_block);
+    ItemStack capBank3 = BlockItemCapBank.createItemStackWithPower(CapBankType.getMetaFromType(CapBankType.VIBRANT), 0);
+    GameRegistry.addShapedRecipe(capBank3, "bcb", "cmc", "bcb", 'b', electricSteel, 'c', capacitor3, 'm', vibCry);
 
     ConvertOldRecipe convertRecipe = new ConvertOldRecipe();
     GameRegistry.addRecipe(convertRecipe);
+
+    GameRegistry.addRecipe(new UpgradeCapBankRecipe(capBank2, "eee", "bcb", "eee", 'e', energeticAlloy, 'b', capBank1, 'c', capacitor2));
 
     //painter
     ItemStack painter = new ItemStack(EnderIO.blockPainter, 1, 0);

--- a/src/main/java/crazypants/enderio/machine/UpgradeCapBankRecipe.java
+++ b/src/main/java/crazypants/enderio/machine/UpgradeCapBankRecipe.java
@@ -1,0 +1,31 @@
+package crazypants.enderio.machine;
+
+import net.minecraft.inventory.InventoryCrafting;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.oredict.ShapedOreRecipe;
+
+import crazypants.enderio.power.PowerHandlerUtil;
+
+public class UpgradeCapBankRecipe extends ShapedOreRecipe {
+
+  public UpgradeCapBankRecipe(ItemStack result, Object... recipe) {
+    super(result, recipe);
+  }
+
+  @Override
+  public ItemStack getCraftingResult(InventoryCrafting var1) {
+    long energy = 0;
+    for(int y=0 ; y<3 ; y++) {
+      for(int x=0 ; x<3 ; x++) {
+        ItemStack st = var1.getStackInRowAndColumn(x, y);
+        if(st != null) {
+          energy += PowerHandlerUtil.getStoredEnergyForItem(st);
+        }
+      }
+    }
+
+    ItemStack res = super.getCraftingResult(var1);
+    PowerHandlerUtil.setStoredEnergyForItem(res, (int)Math.min(Integer.MAX_VALUE, energy));
+    return res;
+  }
+}


### PR DESCRIPTION
Resource cost for normal cap bank crafting:
CoalDust=8, Copper=8, Glowstone=8, GoldNugget=104, Iron=4, Redstone=33, Silicon=4

With upgrade recipe:
CoalDust=1, Copper=10, Glowstone=8, GoldNugget=112, Iron=8, Redstone=46

So a bit cheaper on coal dust and silicon - but overall a bit more expensive.