### PR TITLE
Make Photovoltaic Cell more findable

### DIFF
--- a/resources/assets/enderio/lang/de_DE.lang
+++ b/resources/assets/enderio/lang/de_DE.lang
@@ -167,6 +167,7 @@ tile.blockAlloySmelter.tooltip.detailed.line5=Geschw. und Energiespeicher erhöh
 
 tile.blockSolarPanel.name=Photovoltaikzelle
 tile.blockSolarPanel.advanced.name=Fortgeschrittene Photovoltaikzelle
+tile.blockSolarPanel.tooltip.common.line1=Solarenergie!
 tile.blockSolarPanel.tooltip.detailed.line1=Produziert Energie am Tag
 tile.blockSolarPanel.tooltip.detailed.line2=Braucht klare Sicht
 tile.blockSolarPanel.tooltip.detailed.line3=zum Himmel

--- a/resources/assets/enderio/lang/en_US.lang
+++ b/resources/assets/enderio/lang/en_US.lang
@@ -244,6 +244,7 @@ tile.blockAlloySmelter.tooltip.detailed.line5=speed and energy storage
 
 tile.blockSolarPanel.name=Photovoltaic Cell
 tile.blockSolarPanel.advanced.name=Advanced Photovoltaic Cell
+tile.blockSolarPanel.tooltip.common.line1=Solar power!
 tile.blockSolarPanel.tooltip.detailed.line1=Produces power during daylight hours
 tile.blockSolarPanel.tooltip.detailed.line2=Must have a clear line of sight to
 tile.blockSolarPanel.tooltip.detailed.line3=the sky
@@ -872,6 +873,10 @@ enderio.gui.conduit.item.selfFeedDisabled=Self Feed Disabled
 enderio.gui.conduit.item.roundRobinEnabled=Round Robin Enabled
 enderio.gui.conduit.item.roundRobinDisabled=Round Robin Disabled
 enderio.gui.conduit.item.priority=Priority
+
+enderio.gui.conduit.item.filterupgrade=Insert Item Filter
+enderio.gui.conduit.item.speedupgrade=Insert Item Conduit Speed Up-/ Downgrade
+enderio.gui.conduit.item.speedupgrade2=Max upgrades is 15; Max downgrades is 1
 
 enderio.gui.conduit.redstone.signalColor=Signal Color
 enderio.gui.conduit.redstone.color=Color

--- a/src/main/java/crazypants/enderio/gui/TooltipAddera.java
+++ b/src/main/java/crazypants/enderio/gui/TooltipAddera.java
@@ -286,6 +286,20 @@ public class TooltipAddera {
     }
   }
 
+  public static void addCommonTooltipFromResources(List list, ItemStack itemstack) {
+    if(itemstack.getItem() == null) {
+      return;
+    }
+    String unloc = null;
+    if (itemstack.getItem() instanceof IResourceTooltipProvider) {
+      unloc = ((IResourceTooltipProvider)itemstack.getItem()).getUnlocalizedNameForTooltip(itemstack);
+    }
+    if(unloc == null) {
+      unloc = itemstack.getItem().getUnlocalizedName(itemstack);
+    }
+    addCommonTooltipFromResources(list, unloc);
+  }
+
   public static void addDetailedTooltipFromResources(List list, ItemStack itemstack) {
     if(itemstack.getItem() == null) {
       return;

--- a/src/main/java/crazypants/enderio/gui/TooltipAddera.java
+++ b/src/main/java/crazypants/enderio/gui/TooltipAddera.java
@@ -286,37 +286,29 @@ public class TooltipAddera {
     }
   }
 
+  private static String getUnlocalizedNameForTooltip(ItemStack itemstack) {
+    String unlocalizedNameForTooltip = null;
+    if (itemstack.getItem() instanceof IResourceTooltipProvider) {
+      unlocalizedNameForTooltip = ((IResourceTooltipProvider)itemstack.getItem()).getUnlocalizedNameForTooltip(itemstack);
+    }
+    if(unlocalizedNameForTooltip == null) {
+      unlocalizedNameForTooltip = itemstack.getItem().getUnlocalizedName(itemstack);
+    }
+    return unlocalizedNameForTooltip;
+  }
+
   public static void addCommonTooltipFromResources(List list, ItemStack itemstack) {
     if(itemstack.getItem() == null) {
       return;
     }
-    String unloc = null;
-    if (itemstack.getItem() instanceof IResourceTooltipProvider) {
-      unloc = ((IResourceTooltipProvider)itemstack.getItem()).getUnlocalizedNameForTooltip(itemstack);
-    }
-    if(unloc == null) {
-      unloc = itemstack.getItem().getUnlocalizedName(itemstack);
-    }
-    addCommonTooltipFromResources(list, unloc);
+    addCommonTooltipFromResources(list, getUnlocalizedNameForTooltip(itemstack));
   }
 
   public static void addDetailedTooltipFromResources(List list, ItemStack itemstack) {
     if(itemstack.getItem() == null) {
       return;
     }
-    String unloc = null;
-    //    Block blk = Block.getBlockFromItem(itemstack.getItem());
-    //    if(blk != null && blk != Blocks.air) {
-    //      unlock = blk.getUnlocalizedName();
-    //    }
-    
-    if (itemstack.getItem() instanceof IResourceTooltipProvider) {
-      unloc = ((IResourceTooltipProvider)itemstack.getItem()).getUnlocalizedNameForTooltip(itemstack);
-    }
-    if(unloc == null) {
-      unloc = itemstack.getItem().getUnlocalizedName(itemstack);
-    }
-    addDetailedTooltipFromResources(list, unloc);
+    addDetailedTooltipFromResources(list, getUnlocalizedNameForTooltip(itemstack));
   }
 
   private static class BallTipProvider implements IAdvancedTooltipProvider {

--- a/src/main/java/crazypants/enderio/machine/solar/BlockItemSolarPanel.java
+++ b/src/main/java/crazypants/enderio/machine/solar/BlockItemSolarPanel.java
@@ -12,11 +12,12 @@ import crazypants.enderio.EnderIO;
 import crazypants.enderio.EnderIOTab;
 import crazypants.enderio.config.Config;
 import crazypants.enderio.gui.IAdvancedTooltipProvider;
+import crazypants.enderio.gui.IResourceTooltipProvider;
 import crazypants.enderio.gui.TooltipAddera;
 import crazypants.enderio.machine.power.PowerDisplayUtil;
 import crazypants.util.Lang;
 
-public class BlockItemSolarPanel extends ItemBlockWithMetadata implements IAdvancedTooltipProvider{
+public class BlockItemSolarPanel extends ItemBlockWithMetadata implements IAdvancedTooltipProvider, IResourceTooltipProvider {
 
   public BlockItemSolarPanel() {
     super(EnderIO.blockSolarPanel, EnderIO.blockSolarPanel);
@@ -52,6 +53,7 @@ public class BlockItemSolarPanel extends ItemBlockWithMetadata implements IAdvan
   @SuppressWarnings("rawtypes")
   @Override
   public void addCommonEntries(ItemStack itemstack, EntityPlayer entityplayer, List list, boolean flag) {       
+    TooltipAddera.addCommonTooltipFromResources(list, itemstack);
   }
 
   @SuppressWarnings("rawtypes")
@@ -68,6 +70,11 @@ public class BlockItemSolarPanel extends ItemBlockWithMetadata implements IAdvan
       prod = Config.maxPhotovoltaicAdvancedOutputRF;
     }
     list.add(Lang.localize("maxSolorProduction") + " " + PowerDisplayUtil.formatPowerPerTick(prod));
+  }
+
+  @Override
+  public String getUnlocalizedNameForTooltip(ItemStack itemStack) {
+	  return super.getUnlocalizedName(itemStack);
   }
 
 }


### PR DESCRIPTION
* Photovoltaic Cell now has a common tooltip text
* It says "Solar power" because people search NEI for "solar" not
"photovoltaic"
* Support in TooltipAddera for common tooltips of
IResourceTooltipProviders
* Fixed Advanced Photovoltaic Cell not displaying detailed tooltip text
shared with Photovoltaic Cell in Vanilla tooltip (Waila was ok)