### PR TITLE
Added missing SideOnly annotations

### DIFF
--- a/src/main/java/crazypants/enderio/ClientProxy.java
+++ b/src/main/java/crazypants/enderio/ClientProxy.java
@@ -8,7 +8,6 @@ import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.init.Blocks;
-import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.potion.Potion;
@@ -22,6 +21,8 @@ import cpw.mods.fml.client.registry.ClientRegistry;
 import cpw.mods.fml.client.registry.RenderingRegistry;
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.Loader;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.conduit.BlockConduitBundle;
 import crazypants.enderio.conduit.IConduit;
 import crazypants.enderio.conduit.TileConduitBundle;
@@ -131,6 +132,7 @@ import crazypants.enderio.teleport.TravelController;
 import crazypants.enderio.teleport.TravelEntitySpecialRenderer;
 import crazypants.render.IconUtil;
 
+@SideOnly(Side.CLIENT)
 public class ClientProxy extends CommonProxy {
 
   // @formatter:off
@@ -224,7 +226,7 @@ public class ClientProxy extends CommonProxy {
 
     BlockSolarPanel.renderId = RenderingRegistry.getNextAvailableRenderId();
     RenderingRegistry.registerBlockHandler(new SolarPanelRenderer());
-    
+
     EnchanterModelRenderer emr = new EnchanterModelRenderer();
     ClientRegistry.bindTileEntitySpecialRenderer(TileEnchanter.class, emr);
     MinecraftForgeClient.registerItemRenderer(Item.getItemFromBlock(EnderIO.blockEnchanter), emr);
@@ -259,7 +261,7 @@ public class ClientProxy extends CommonProxy {
     BlockWeatherObelisk.renderId = BlockAttractor.renderId;
     ClientRegistry.bindTileEntitySpecialRenderer(TileWeatherObelisk.class, twr);
     MinecraftForgeClient.registerItemRenderer(Item.getItemFromBlock(EnderIO.blockWeatherObelisk), twr);
-    
+
     if(Config.useCombustionGenModel) {
       CombustionGeneratorModelRenderer cgmr = new CombustionGeneratorModelRenderer();
       ClientRegistry.bindTileEntitySpecialRenderer(TileCombustionGenerator.class, cgmr);

--- a/src/main/java/crazypants/enderio/EnderIOTab.java
+++ b/src/main/java/crazypants/enderio/EnderIOTab.java
@@ -1,10 +1,10 @@
 package crazypants.enderio;
 
+import static crazypants.enderio.EnderIO.MODID;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.item.Item;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
-import static crazypants.enderio.EnderIO.*;
 
 public class EnderIOTab extends CreativeTabs {
 
@@ -27,6 +27,7 @@ public class EnderIOTab extends CreativeTabs {
   }
 
     @Override
+    @SideOnly(Side.CLIENT)
     public Item getTabIconItem() {
         return EnderIO.itemEnderface;
     }

--- a/src/main/java/crazypants/enderio/block/BlockDarkSteelPressurePlate.java
+++ b/src/main/java/crazypants/enderio/block/BlockDarkSteelPressurePlate.java
@@ -56,6 +56,7 @@ public class BlockDarkSteelPressurePlate extends BlockPressurePlate implements I
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public void registerBlockIcons(IIconRegister iIconRegister) {
     blockIcon = iIconRegister.registerIcon("enderio:" + ModObject.blockDarkSteelPressurePlate.unlocalisedName);
   }
@@ -69,6 +70,7 @@ public class BlockDarkSteelPressurePlate extends BlockPressurePlate implements I
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public IIcon getIcon(IBlockAccess world, int x, int y, int z, int blockSide) {
     TileEntity te = world.getTileEntity(x, y, z);
     if(te instanceof TileEntityPaintedBlock) {

--- a/src/main/java/crazypants/enderio/conduit/AbstractItemConduit.java
+++ b/src/main/java/crazypants/enderio/conduit/AbstractItemConduit.java
@@ -14,6 +14,8 @@ import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 import cpw.mods.fml.common.registry.GameRegistry;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.EnderIO;
 import crazypants.enderio.EnderIOTab;
 import crazypants.enderio.ModObject;
@@ -43,6 +45,7 @@ public abstract class AbstractItemConduit extends Item implements IConduitItem {
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public void registerIcons(IIconRegister IIconRegister) {
     int index = 0;
     for (ItemConduitSubtype subtype : subtypes) {
@@ -108,6 +111,7 @@ public abstract class AbstractItemConduit extends Item implements IConduitItem {
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public IIcon getIconFromDamage(int damage) {
     damage = MathHelper.clamp_int(damage, 0, subtypes.length - 1);
     return icons[damage];
@@ -122,6 +126,7 @@ public abstract class AbstractItemConduit extends Item implements IConduitItem {
 
   @Override
   @SuppressWarnings({ "rawtypes", "unchecked" })
+  @SideOnly(Side.CLIENT)
   public void getSubItems(Item par1, CreativeTabs par2CreativeTabs, List par3List) {
     for (int j = 0; j < subtypes.length; ++j) {
       par3List.add(new ItemStack(this, 1, j));

--- a/src/main/java/crazypants/enderio/conduit/BlockConduitBundle.java
+++ b/src/main/java/crazypants/enderio/conduit/BlockConduitBundle.java
@@ -337,14 +337,15 @@ public class BlockConduitBundle extends BlockEio implements IGuiHandler, IFacade
       }
     }
   }
-  
+
   @Override
+  @SideOnly(Side.CLIENT)
   public int getRenderBlockPass() {
     return 1;
   }
-  
+
   public static volatile int theRenderPass;
-  
+
   @Override
   public boolean canRenderInPass(int pass) {
     theRenderPass = pass;
@@ -760,6 +761,7 @@ public class BlockConduitBundle extends BlockEio implements IGuiHandler, IFacade
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public AxisAlignedBB getSelectedBoundingBoxFromPool(World world, int x, int
       y, int z) {
 
@@ -851,7 +853,7 @@ public class BlockConduitBundle extends BlockEio implements IGuiHandler, IFacade
     }
     IConduitBundle bundle = (IConduitBundle) te;
     List<RaytraceResult> hits = new ArrayList<RaytraceResult>();
-    
+
     if (player == null) {
       player = EnderIO.proxy.getClientPlayer();
     }

--- a/src/main/java/crazypants/enderio/conduit/facade/BlockConduitFacade.java
+++ b/src/main/java/crazypants/enderio/conduit/facade/BlockConduitFacade.java
@@ -32,6 +32,7 @@ public class BlockConduitFacade extends BlockEio implements IPaintedBlock {
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public void registerBlockIcons(IIconRegister IIconRegister) {
     blockIcon = IIconRegister.registerIcon("enderio:conduitFacade");
   }

--- a/src/main/java/crazypants/enderio/conduit/facade/ItemConduitFacade.java
+++ b/src/main/java/crazypants/enderio/conduit/facade/ItemConduitFacade.java
@@ -27,8 +27,8 @@ import crazypants.enderio.machine.painter.BasicPainterTemplate;
 import crazypants.enderio.machine.painter.IPaintedBlock;
 import crazypants.enderio.machine.painter.PaintSourceValidator;
 import crazypants.enderio.machine.painter.PainterUtil;
-import crazypants.util.Util;
 import crazypants.util.Lang;
+import crazypants.util.Util;
 
 public class ItemConduitFacade extends Item implements IAdvancedTooltipProvider, IResourceTooltipProvider {
 
@@ -63,6 +63,7 @@ public class ItemConduitFacade extends Item implements IAdvancedTooltipProvider,
 
   @SuppressWarnings({ "unchecked", "rawtypes" })
   @Override
+  @SideOnly(Side.CLIENT)
   public void getSubItems(Item item, CreativeTabs p_150895_2_, List list) {
     for (FacadeType t : FacadeType.values()) {
       list.add(new ItemStack(item, 1, t.ordinal()));
@@ -80,6 +81,7 @@ public class ItemConduitFacade extends Item implements IAdvancedTooltipProvider,
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public void registerIcons(IIconRegister IIconRegister) {
     icons = new IIcon[FacadeType.values().length];
     icons[0] = itemIcon = IIconRegister.registerIcon("enderio:conduitFacade");
@@ -92,6 +94,7 @@ public class ItemConduitFacade extends Item implements IAdvancedTooltipProvider,
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public IIcon getIconFromDamage(int damage) {
     return icons[damage % icons.length];
   }

--- a/src/main/java/crazypants/enderio/conduit/item/ItemExtractSpeedUpgrade.java
+++ b/src/main/java/crazypants/enderio/conduit/item/ItemExtractSpeedUpgrade.java
@@ -21,7 +21,7 @@ public class ItemExtractSpeedUpgrade extends Item implements IResourceTooltipPro
 
   private final IIcon[] icons;
 
-  public static ItemExtractSpeedUpgrade create() {    
+  public static ItemExtractSpeedUpgrade create() {
     ItemExtractSpeedUpgrade result = new ItemExtractSpeedUpgrade();
     result.init();
     return result;
@@ -42,6 +42,7 @@ public class ItemExtractSpeedUpgrade extends Item implements IResourceTooltipPro
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public IIcon getIconFromDamage(int damage) {
     damage = MathHelper.clamp_int(damage, 0, icons.length - 1);
     return icons[damage];
@@ -62,6 +63,7 @@ public class ItemExtractSpeedUpgrade extends Item implements IResourceTooltipPro
 
   @Override
   @SuppressWarnings({ "rawtypes", "unchecked" })
+  @SideOnly(Side.CLIENT)
   public void getSubItems(Item par1, CreativeTabs par2CreativeTabs, List par3List) {
     for (int j = 0; j < UPGRADES.length; ++j) {
       par3List.add(new ItemStack(par1, 1, j));

--- a/src/main/java/crazypants/enderio/conduit/item/filter/ItemBasicItemFilter.java
+++ b/src/main/java/crazypants/enderio/conduit/item/filter/ItemBasicItemFilter.java
@@ -53,23 +53,25 @@ public class ItemBasicItemFilter extends Item implements IItemFilterUpgrade {
       filter = new ItemFilter(true);
     }
     if(stack.stackTagCompound != null && stack.stackTagCompound.hasKey("filter")) {
-      filter.readFromNBT(stack.stackTagCompound.getCompoundTag("filter"));      
+      filter.readFromNBT(stack.stackTagCompound.getCompoundTag("filter"));
     }
     return filter;
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public IIcon getIconFromDamage(int damage) {
     damage = MathHelper.clamp_int(damage, 0, 1);
     return icons[damage];
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public void registerIcons(IIconRegister IIconRegister) {
-    
+
     icons[0] = IIconRegister.registerIcon("enderio:filterUpgradeBasic");
     icons[1] = IIconRegister.registerIcon("enderio:filterUpgradeAdvanced");
-    
+
   }
 
   @Override
@@ -80,6 +82,7 @@ public class ItemBasicItemFilter extends Item implements IItemFilterUpgrade {
 
   @Override
   @SuppressWarnings({ "rawtypes", "unchecked" })
+  @SideOnly(Side.CLIENT)
   public void getSubItems(Item par1, CreativeTabs par2CreativeTabs, List par3List) {
     for (int j = 0; j < 2; ++j) {
       par3List.add(new ItemStack(this, 1, j));
@@ -88,18 +91,18 @@ public class ItemBasicItemFilter extends Item implements IItemFilterUpgrade {
 
   @Override
   @SideOnly(Side.CLIENT)
-  public void addInformation(ItemStack par1ItemStack, EntityPlayer par2EntityPlayer, List par3List, boolean par4) {          
-    if(FilterRegister.isFilterSet(par1ItemStack)) {      
+  public void addInformation(ItemStack par1ItemStack, EntityPlayer par2EntityPlayer, List par3List, boolean par4) {
+    if(FilterRegister.isFilterSet(par1ItemStack)) {
       if(!TooltipAddera.instance.showAdvancedTooltips()) {
         par3List.add(Lang.localize("itemConduitFilterUpgrade"));
         TooltipAddera.instance.addShowDetailsTooltip(par3List);
       } else {
         par3List.add(EnumChatFormatting.ITALIC + Lang.localize("itemConduitFilterUpgrade.configured"));
         par3List.add(EnumChatFormatting.ITALIC + Lang.localize("itemConduitFilterUpgrade.clearConfigMethod"));
-      }      
+      }
     } else {
       par3List.add(Lang.localize("itemConduitFilterUpgrade"));
     }
   }
-  
+
 }

--- a/src/main/java/crazypants/enderio/conduit/item/filter/ItemExistingItemFilter.java
+++ b/src/main/java/crazypants/enderio/conduit/item/filter/ItemExistingItemFilter.java
@@ -4,9 +4,13 @@ import java.util.List;
 
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.IInventory;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.EnumChatFormatting;
+import net.minecraft.world.World;
 import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
@@ -17,10 +21,6 @@ import crazypants.enderio.gui.IResourceTooltipProvider;
 import crazypants.enderio.gui.TooltipAddera;
 import crazypants.util.ItemUtil;
 import crazypants.util.Lang;
-import net.minecraft.inventory.IInventory;
-import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.ChatComponentText;
-import net.minecraft.world.World;
 
 public class ItemExistingItemFilter extends Item implements IItemFilterUpgrade, IResourceTooltipProvider {
 
@@ -76,6 +76,7 @@ public class ItemExistingItemFilter extends Item implements IItemFilterUpgrade, 
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public void registerIcons(IIconRegister IIconRegister) {
     itemIcon = IIconRegister.registerIcon("enderio:existingItemFilter");
   }
@@ -84,7 +85,7 @@ public class ItemExistingItemFilter extends Item implements IItemFilterUpgrade, 
   public String getUnlocalizedNameForTooltip(ItemStack stack) {
     return getUnlocalizedName();
   }
-  
+
   @Override
   @SideOnly(Side.CLIENT)
   public void addInformation(ItemStack par1ItemStack, EntityPlayer par2EntityPlayer, List par3List, boolean par4) {

--- a/src/main/java/crazypants/enderio/conduit/item/filter/ItemModItemFilter.java
+++ b/src/main/java/crazypants/enderio/conduit/item/filter/ItemModItemFilter.java
@@ -27,7 +27,7 @@ public class ItemModItemFilter extends Item implements IItemFilterUpgrade, IReso
 
   protected ItemModItemFilter() {
     setCreativeTab(EnderIOTab.tabEnderIO);
-    setUnlocalizedName(ModObject.itemModItemFilter.unlocalisedName);    
+    setUnlocalizedName(ModObject.itemModItemFilter.unlocalisedName);
     setMaxDamage(0);
     setMaxStackSize(64);
   }
@@ -46,6 +46,7 @@ public class ItemModItemFilter extends Item implements IItemFilterUpgrade, IReso
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public void registerIcons(IIconRegister IIconRegister) {
     itemIcon = IIconRegister.registerIcon("enderio:modItemFilter");
   }
@@ -54,15 +55,15 @@ public class ItemModItemFilter extends Item implements IItemFilterUpgrade, IReso
   public String getUnlocalizedNameForTooltip(ItemStack stack) {
     return getUnlocalizedName();
   }
-  
+
   @Override
   @SideOnly(Side.CLIENT)
-  public void addInformation(ItemStack par1ItemStack, EntityPlayer par2EntityPlayer, List par3List, boolean par4) {          
-    if(FilterRegister.isFilterSet(par1ItemStack)) {      
-      if(TooltipAddera.instance.showAdvancedTooltips()) {        
+  public void addInformation(ItemStack par1ItemStack, EntityPlayer par2EntityPlayer, List par3List, boolean par4) {
+    if(FilterRegister.isFilterSet(par1ItemStack)) {
+      if(TooltipAddera.instance.showAdvancedTooltips()) {
         par3List.add(EnumChatFormatting.ITALIC + Lang.localize("itemConduitFilterUpgrade.configured"));
         par3List.add(EnumChatFormatting.ITALIC + Lang.localize("itemConduitFilterUpgrade.clearConfigMethod"));
-      }      
+      }
     }
   }
 

--- a/src/main/java/crazypants/enderio/conduit/item/filter/ItemPowerItemFilter.java
+++ b/src/main/java/crazypants/enderio/conduit/item/filter/ItemPowerItemFilter.java
@@ -1,24 +1,14 @@
 package crazypants.enderio.conduit.item.filter;
 
-import java.util.List;
-
 import net.minecraft.client.renderer.texture.IIconRegister;
-import net.minecraft.creativetab.CreativeTabs;
-import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
-import net.minecraft.util.EnumChatFormatting;
-import net.minecraft.util.IIcon;
-import net.minecraft.util.MathHelper;
 import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.EnderIOTab;
 import crazypants.enderio.ModObject;
-import crazypants.enderio.conduit.item.FilterRegister;
 import crazypants.enderio.gui.IResourceTooltipProvider;
-import crazypants.enderio.gui.TooltipAddera;
-import crazypants.util.Lang;
 
 /**
  *
@@ -54,6 +44,7 @@ public class ItemPowerItemFilter extends Item implements IItemFilterUpgrade, IRe
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public void registerIcons(IIconRegister IIconRegister) {
     itemIcon = IIconRegister.registerIcon("enderio:filterUpgradePower");
   }

--- a/src/main/java/crazypants/enderio/conduit/redstone/RedstoneSwitch.java
+++ b/src/main/java/crazypants/enderio/conduit/redstone/RedstoneSwitch.java
@@ -10,6 +10,8 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.IIcon;
 import net.minecraftforge.common.util.ForgeDirection;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.EnderIO;
 import crazypants.enderio.conduit.RaytraceResult;
 import crazypants.enderio.conduit.geom.CollidableComponent;
@@ -29,6 +31,7 @@ public class RedstoneSwitch extends RedstoneConduit {
 
   private boolean isOn;
 
+  @SideOnly(Side.CLIENT)
   public static void initIcons() {
     IconUtil.addIconProvider(new IconUtil.IIconProvider() {
 

--- a/src/main/java/crazypants/enderio/conduit/render/ConduitBundleRenderer.java
+++ b/src/main/java/crazypants/enderio/conduit/render/ConduitBundleRenderer.java
@@ -34,8 +34,8 @@ import crazypants.enderio.conduit.ConduitUtil;
 import crazypants.enderio.conduit.ConnectionMode;
 import crazypants.enderio.conduit.IConduit;
 import crazypants.enderio.conduit.IConduitBundle;
-import crazypants.enderio.conduit.RaytraceResult;
 import crazypants.enderio.conduit.IConduitBundle.FacadeRenderState;
+import crazypants.enderio.conduit.RaytraceResult;
 import crazypants.enderio.conduit.TileConduitBundle;
 import crazypants.enderio.conduit.facade.BlockConduitFacade;
 import crazypants.enderio.conduit.geom.CollidableComponent;
@@ -49,6 +49,7 @@ import crazypants.render.RenderUtil;
 import crazypants.util.BlockCoord;
 import crazypants.util.IBlockAccessWrapper;
 
+@SideOnly(Side.CLIENT)
 public class ConduitBundleRenderer extends TileEntitySpecialRenderer implements ISimpleBlockRenderingHandler {
 
   public ConduitBundleRenderer(float conduitScale) {
@@ -105,7 +106,7 @@ public class ConduitBundleRenderer extends TileEntitySpecialRenderer implements 
   @Override
   public boolean renderWorldBlock(IBlockAccess world, int x, int y, int z, Block block, int modelId, RenderBlocks rb) {
 
-    //If the MC renderer is told that an alpha pass is required ( see BlockConduitBundle.getRenderBlockPass() ) put 
+    //If the MC renderer is told that an alpha pass is required ( see BlockConduitBundle.getRenderBlockPass() ) put
     //nothing is actually added to the tessellator in this pass then the renderer will crash. We cant selectively
     //enable the alpha pass based on state so the only work around is to ensure we always render something in this
     //pass. Throwing in a polygon with a 0 area does the job

--- a/src/main/java/crazypants/enderio/enderface/BlockEnderIO.java
+++ b/src/main/java/crazypants/enderio/enderface/BlockEnderIO.java
@@ -1,6 +1,5 @@
 package crazypants.enderio.enderface;
 
-import net.minecraft.block.Block;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
@@ -10,6 +9,7 @@ import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
+import net.minecraftforge.common.UsernameCache;
 import cpw.mods.fml.common.network.IGuiHandler;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
@@ -23,7 +23,6 @@ import crazypants.enderio.gui.IResourceTooltipProvider;
 import crazypants.enderio.network.PacketHandler;
 import crazypants.enderio.teleport.ITravelAccessable;
 import crazypants.util.Lang;
-import net.minecraftforge.common.UsernameCache;
 
 public class BlockEnderIO extends BlockEio implements IResourceTooltipProvider {
 
@@ -131,6 +130,7 @@ public class BlockEnderIO extends BlockEio implements IResourceTooltipProvider {
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public void registerBlockIcons(IIconRegister iIconRegister) {
     super.registerBlockIcons(iIconRegister);
     frameIcon = iIconRegister.registerIcon("enderio:enderIOFrame");

--- a/src/main/java/crazypants/enderio/enderface/EnderIoRenderer.java
+++ b/src/main/java/crazypants/enderio/enderface/EnderIoRenderer.java
@@ -12,6 +12,8 @@ import net.minecraftforge.client.IItemRenderer;
 
 import org.lwjgl.opengl.GL11;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.EnderIO;
 import crazypants.enderio.teleport.TravelEntitySpecialRenderer;
 import crazypants.render.BoundingBox;
@@ -21,6 +23,7 @@ import crazypants.vecmath.Matrix4d;
 import crazypants.vecmath.VecmathUtil;
 import crazypants.vecmath.Vector3d;
 
+@SideOnly(Side.CLIENT)
 public class EnderIoRenderer extends TileEntitySpecialRenderer implements IItemRenderer {
 
   private TravelEntitySpecialRenderer selectionRenderer = new TravelEntitySpecialRenderer() {
@@ -42,7 +45,7 @@ public class EnderIoRenderer extends TileEntitySpecialRenderer implements IItemR
   @Override
   public void renderTileEntityAt(TileEntity te, double x, double y, double z, float f) {
 
-    
+
     EntityLivingBase entityPlayer = Minecraft.getMinecraft().thePlayer;
     Matrix4d lookMat = RenderUtil.createBillboardMatrix(te, entityPlayer);
 

--- a/src/main/java/crazypants/enderio/enderface/ItemEnderface.java
+++ b/src/main/java/crazypants/enderio/enderface/ItemEnderface.java
@@ -8,6 +8,8 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.World;
 import cpw.mods.fml.common.network.IGuiHandler;
 import cpw.mods.fml.common.registry.GameRegistry;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.EnderIO;
 import crazypants.enderio.GuiHandler;
 import crazypants.enderio.ModObject;
@@ -38,11 +40,13 @@ public class ItemEnderface extends Item implements IGuiHandler {
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public void registerIcons(IIconRegister IIconRegister) {
     itemIcon = IIconRegister.registerIcon("enderio:enderface");
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public boolean hasEffect(ItemStack par1ItemStack, int pass) {
     return true;
   }

--- a/src/main/java/crazypants/enderio/fluid/BlockFluidEio.java
+++ b/src/main/java/crazypants/enderio/fluid/BlockFluidEio.java
@@ -26,7 +26,7 @@ public class BlockFluidEio extends BlockFluidClassic {
   public static BlockFluidEio create(Fluid fluid, Material material) {
     BlockFluidEio res = new BlockFluidEio(fluid, material);
     res.init();
-    fluid.setBlock(res);    
+    fluid.setBlock(res);
     return res;
   }
 
@@ -46,6 +46,7 @@ public class BlockFluidEio extends BlockFluidClassic {
   protected IIcon[] icons;
 
   @Override
+  @SideOnly(Side.CLIENT)
   public IIcon getIcon(int side, int meta) {
     return side != 0 && side != 1 ? this.icons[1] : this.icons[0];
   }

--- a/src/main/java/crazypants/enderio/item/ItemMagnet.java
+++ b/src/main/java/crazypants/enderio/item/ItemMagnet.java
@@ -23,9 +23,9 @@ import crazypants.enderio.machine.power.PowerDisplayUtil;
 import crazypants.util.ItemUtil;
 
 public class ItemMagnet extends ItemEnergyContainer implements IResourceTooltipProvider {
-  
+
   private static final String ACTIVE_KEY = "magnetActive";
-  
+
   public static void setActive(ItemStack item, boolean active) {
     if(item == null) {
       return;
@@ -33,7 +33,7 @@ public class ItemMagnet extends ItemEnergyContainer implements IResourceTooltipP
     NBTTagCompound nbt = ItemUtil.getOrCreateNBT(item);
     nbt.setBoolean(ACTIVE_KEY, active);
   }
-  
+
   public static boolean isActive(ItemStack item) {
     if(item == null) {
       return false;
@@ -44,29 +44,29 @@ public class ItemMagnet extends ItemEnergyContainer implements IResourceTooltipP
     if(!item.stackTagCompound.hasKey(ACTIVE_KEY)) {
       return false;
     }
-    return item.stackTagCompound.getBoolean(ACTIVE_KEY);    
+    return item.stackTagCompound.getBoolean(ACTIVE_KEY);
   }
-  
-  public static boolean hasPower(ItemStack itemStack) {    
+
+  public static boolean hasPower(ItemStack itemStack) {
     return EnderIO.itemMagnet.getEnergyStored(itemStack) > 0;
   }
 
   public static void drainPerSecondPower(ItemStack itemStack) {
-    EnderIO.itemMagnet.extractEnergy(itemStack, Config.magnetPowerUsePerSecondRF, false);    
+    EnderIO.itemMagnet.extractEnergy(itemStack, Config.magnetPowerUsePerSecondRF, false);
   }
 
-  public static ItemMagnet create() {    
+  public static ItemMagnet create() {
     ItemMagnet result = new ItemMagnet();
-    result.init();    
-    FMLCommonHandler.instance().bus().register(new MagnetController());    
+    result.init();
+    FMLCommonHandler.instance().bus().register(new MagnetController());
     return result;
   }
 
-  
+
   protected ItemMagnet() {
     super(Config.magnetPowerCapacityRF, Config.magnetPowerCapacityRF/100);
     setCreativeTab(EnderIOTab.tabEnderIO);
-    setUnlocalizedName(ModObject.itemMagnet.unlocalisedName);    
+    setUnlocalizedName(ModObject.itemMagnet.unlocalisedName);
     setMaxDamage(16);
     setMaxStackSize(1);
     setHasSubtypes(true);
@@ -81,7 +81,7 @@ public class ItemMagnet extends ItemEnergyContainer implements IResourceTooltipP
   public void registerIcons(IIconRegister IIconRegister) {
     itemIcon = IIconRegister.registerIcon("enderio:magnet");
   }
-  
+
   @Override
   @SideOnly(Side.CLIENT)
   public void getSubItems(Item item, CreativeTabs par2CreativeTabs, List par3List) {
@@ -93,7 +93,7 @@ public class ItemMagnet extends ItemEnergyContainer implements IResourceTooltipP
     setEnergy(is, 0);
     par3List.add(is);
   }
-  
+
   @Override
   @SideOnly(Side.CLIENT)
   public void addInformation(ItemStack itemStack, EntityPlayer par2EntityPlayer, List list, boolean par4) {
@@ -102,17 +102,18 @@ public class ItemMagnet extends ItemEnergyContainer implements IResourceTooltipP
         + PowerDisplayUtil.formatPower(getMaxEnergyStored(itemStack)) + " " + PowerDisplayUtil.abrevation();
     list.add(str);
   }
-  
+
   @Override
-  public boolean hasEffect(ItemStack item, int pass) {    
+  @SideOnly(Side.CLIENT)
+  public boolean hasEffect(ItemStack item, int pass) {
     return isActive(item);
   }
-  
+
   @Override
   public void onCreated(ItemStack itemStack, World world, EntityPlayer entityPlayer) {
     setEnergy(itemStack, 0);
   }
-  
+
   @Override
   public int receiveEnergy(ItemStack container, int maxReceive, boolean simulate) {
     int res = super.receiveEnergy(container, maxReceive, simulate);
@@ -151,10 +152,10 @@ public class ItemMagnet extends ItemEnergyContainer implements IResourceTooltipP
 
 
   @Override
-  public ItemStack onItemRightClick(ItemStack equipped, World world, EntityPlayer player) {           
-    if(player.isSneaking()) {      
+  public ItemStack onItemRightClick(ItemStack equipped, World world, EntityPlayer player) {
+    if(player.isSneaking()) {
       setActive(equipped, !isActive(equipped));
-    } 
+    }
     return equipped;
   }
 

--- a/src/main/java/crazypants/enderio/item/ItemSoulVessel.java
+++ b/src/main/java/crazypants/enderio/item/ItemSoulVessel.java
@@ -47,7 +47,7 @@ public class ItemSoulVessel extends Item implements IResourceTooltipProvider {
   }
 
   private IIcon filledIcon;
-  
+
   private List<String> blackList;
 
   protected ItemSoulVessel() {
@@ -79,21 +79,22 @@ public class ItemSoulVessel extends Item implements IResourceTooltipProvider {
   public IIcon getIcon(ItemStack item, int arg1, EntityPlayer arg2, ItemStack arg3, int arg4) {
      if(containsSoul(item)) {
        return filledIcon;
-     } 
-     return itemIcon;         
-  }  
+     }
+     return itemIcon;
+  }
 
   @Override
   @SideOnly(Side.CLIENT)
   public IIcon getIconIndex(ItemStack item) {
     if(containsSoul(item)) {
       return filledIcon;
-    } 
+    }
     return itemIcon;
   }
 
   @Override
-  public boolean hasEffect(ItemStack item, int pass) {       
+  @SideOnly(Side.CLIENT)
+  public boolean hasEffect(ItemStack item, int pass) {
     return containsSoul(item);
   }
 
@@ -114,7 +115,7 @@ public class ItemSoulVessel extends Item implements IResourceTooltipProvider {
     }
 
     Entity mob;
-    NBTTagCompound root = itemstack.stackTagCompound;    
+    NBTTagCompound root = itemstack.stackTagCompound;
     if(root.hasKey("isStub")) {
       String entityId = root.getString("id");
       mob = EntityList.createEntityByName(entityId, world);
@@ -122,18 +123,18 @@ public class ItemSoulVessel extends Item implements IResourceTooltipProvider {
       mob = EntityList.createEntityFromNBT(root, world);
     }
     if (mob == null) {
-      return true;      
+      return true;
     }
     mob.readFromNBT(root);
-    
-    Block blk = world.getBlock(x,y,z);    
+
+    Block blk = world.getBlock(x,y,z);
     double spawnX = x + Facing.offsetsXForSide[side] + 0.5;
     double spawnY = y + Facing.offsetsYForSide[side];
     double spawnZ = z + Facing.offsetsZForSide[side] + 0.5;
     if(side == ForgeDirection.UP.ordinal() && (blk instanceof BlockFence || blk instanceof BlockWall)) {
       spawnY += 0.5;
-    }    
-    mob.setLocationAndAngles(spawnX, spawnY, spawnZ, world.rand.nextFloat() * 360.0F, 0);  
+    }
+    mob.setLocationAndAngles(spawnX, spawnY, spawnZ, world.rand.nextFloat() * 360.0F, 0);
 
     boolean spaceClear = world.checkNoEntityCollision(mob.boundingBox)
         && world.getCollidingBoundingBoxes(mob, mob.boundingBox).isEmpty();
@@ -145,26 +146,26 @@ public class ItemSoulVessel extends Item implements IResourceTooltipProvider {
       ((EntityLiving)mob).setCustomNameTag(itemstack.getDisplayName());
     }
 
-    world.spawnEntityInWorld(mob);    
+    world.spawnEntityInWorld(mob);
     if(mob instanceof EntityLiving) {
       ((EntityLiving)mob).playLivingSound();
     }
-    
+
     Entity riddenByEntity = mob.riddenByEntity;
-    while(riddenByEntity != null) {      
-      riddenByEntity.setLocationAndAngles(spawnX, spawnY, spawnZ, world.rand.nextFloat() * 360.0F, 0.0F);      
+    while(riddenByEntity != null) {
+      riddenByEntity.setLocationAndAngles(spawnX, spawnY, spawnZ, world.rand.nextFloat() * 360.0F, 0.0F);
       world.spawnEntityInWorld(riddenByEntity);
       if(riddenByEntity instanceof EntityLiving) {
         ((EntityLiving)riddenByEntity).playLivingSound();
-      }      
+      }
       riddenByEntity = riddenByEntity.riddenByEntity;
     }
-    
-    
+
+
     if(player == null || !player.capabilities.isCreativeMode) {
       itemstack.setTagCompound(null);
     }
-    
+
     return true;
   }
 
@@ -181,20 +182,20 @@ public class ItemSoulVessel extends Item implements IResourceTooltipProvider {
     if(entity instanceof EntityPlayer) {
       return false;
     }
-    
+
     String entityId = EntityList.getEntityString(entity);
     if(isBlackListed(entityId)) {
       return false;
     }
-    
+
     if(!Config.soulVesselCapturesBosses && entity instanceof IBossDisplayData) {
       return false;
     }
-    
+
     NBTTagCompound root = new NBTTagCompound();
-    root.setString("id", entityId);    
+    root.setString("id", entityId);
     entity.writeToNBT(root);
-    
+
     ItemStack capturedMobVessel = new ItemStack(EnderIO.itemSoulVessel);
     capturedMobVessel.setTagCompound(root);
     setDisplayNameFromEntityNameTag(capturedMobVessel, entity);
@@ -222,7 +223,7 @@ public class ItemSoulVessel extends Item implements IResourceTooltipProvider {
     }
     return false;
   }
-  
+
   public ItemStack createVesselWithEntityStub(String entityId) {
     NBTTagCompound root = new NBTTagCompound();
     root.setString("id", entityId);
@@ -265,10 +266,10 @@ public class ItemSoulVessel extends Item implements IResourceTooltipProvider {
     }
     if(item.getItem() != this) {
       return false;
-    }    
-    return item.stackTagCompound != null && item.stackTagCompound.hasKey("id");    
+    }
+    return item.stackTagCompound != null && item.stackTagCompound.hasKey("id");
   }
-  
+
   public String getMobTypeFromStack(ItemStack item) {
     if(!containsSoul(item)) {
       return null;
@@ -355,7 +356,7 @@ public class ItemSoulVessel extends Item implements IResourceTooltipProvider {
   public String getUnlocalizedNameForTooltip(ItemStack itemStack) {
     return getUnlocalizedName(itemStack);
   }
-  
+
   @Override
   @SideOnly(Side.CLIENT)
   public void addInformation(ItemStack par1ItemStack, EntityPlayer par2EntityPlayer, List par3List, boolean par4) {
@@ -393,6 +394,6 @@ public class ItemSoulVessel extends Item implements IResourceTooltipProvider {
     }
   }
 
-  
+
 
 }

--- a/src/main/java/crazypants/enderio/item/ItemYetaWrench.java
+++ b/src/main/java/crazypants/enderio/item/ItemYetaWrench.java
@@ -23,7 +23,6 @@ import crazypants.enderio.EnderIOTab;
 import crazypants.enderio.ModObject;
 import crazypants.enderio.api.tool.IConduitControl;
 import crazypants.enderio.api.tool.ITool;
-import crazypants.enderio.conduit.BlockConduitBundle;
 import crazypants.enderio.conduit.ConduitDisplayMode;
 import crazypants.enderio.config.Config;
 import crazypants.enderio.gui.IAdvancedTooltipProvider;
@@ -105,6 +104,7 @@ public class ItemYetaWrench extends Item implements ITool, IConduitControl, IAdv
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public boolean isFull3D() {
     return true;
   }
@@ -122,30 +122,30 @@ public class ItemYetaWrench extends Item implements ITool, IConduitControl, IAdv
   @Override
   public void used(ItemStack stack, EntityPlayer player, int x, int y, int z) {
   }
-  
+
   @Override
   public boolean shouldHideFacades(ItemStack stack, EntityPlayer player) {
     ConduitDisplayMode curMode = ConduitDisplayMode.getDisplayMode(stack);
     return curMode != ConduitDisplayMode.NONE;
   }
-  
+
   @Override
   public boolean showOverlay(ItemStack stack, EntityPlayer player) {
     return true;
   }
 
   /* IAdvancedTooltipProvider */
-  
+
   @SuppressWarnings("rawtypes")
   @Override
   public void addBasicEntries(ItemStack itemstack, EntityPlayer entityplayer, List list, boolean flag) {
   }
-  
+
   @SuppressWarnings("rawtypes")
   @Override
   public void addCommonEntries(ItemStack itemstack, EntityPlayer entityplayer, List list, boolean flag) {
   }
-  
+
   @SuppressWarnings({ "rawtypes", "unchecked" })
   @Override
   public void addDetailedEntries(ItemStack itemstack, EntityPlayer entityplayer, List list, boolean flag) {
@@ -158,7 +158,7 @@ public class ItemYetaWrench extends Item implements ITool, IConduitControl, IAdv
   }
 
   /* InvocationHandler */
-  
+
   @Override
   public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
     System.out.println("ItemYetaWrench.invoke: method = " + method.getName());

--- a/src/main/java/crazypants/enderio/item/darksteel/ItemGliderWing.java
+++ b/src/main/java/crazypants/enderio/item/darksteel/ItemGliderWing.java
@@ -2,24 +2,20 @@ package crazypants.enderio.item.darksteel;
 
 import java.util.List;
 
+import net.minecraft.client.renderer.texture.IIconRegister;
+import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.IIcon;
+import net.minecraft.util.MathHelper;
 import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.EnderIOTab;
 import crazypants.enderio.ModObject;
 import crazypants.enderio.gui.IResourceTooltipProvider;
-import crazypants.enderio.material.ItemCapacitor;
 import crazypants.enderio.power.BasicCapacitor;
 import crazypants.enderio.power.Capacitors;
-import crazypants.enderio.power.ICapacitor;
-import crazypants.util.Lang;
-import net.minecraft.client.renderer.texture.IIconRegister;
-import net.minecraft.creativetab.CreativeTabs;
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.item.Item;
-import net.minecraft.item.ItemStack;
-import net.minecraft.util.IIcon;
-import net.minecraft.util.MathHelper;
 
 public class ItemGliderWing extends Item implements IResourceTooltipProvider {
 
@@ -46,6 +42,7 @@ public class ItemGliderWing extends Item implements IResourceTooltipProvider {
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public IIcon getIconFromDamage(int damage) {
     damage = MathHelper.clamp_int(damage, 0, 1);
     if(damage == 0) {
@@ -55,6 +52,7 @@ public class ItemGliderWing extends Item implements IResourceTooltipProvider {
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public void registerIcons(IIconRegister register) {
     itemIcon = register.registerIcon("enderio:itemGliderWing");
     wingsIcon = register.registerIcon("enderio:itemGliderWings");
@@ -71,6 +69,7 @@ public class ItemGliderWing extends Item implements IResourceTooltipProvider {
 
   @Override
   @SuppressWarnings({ "rawtypes", "unchecked" })
+  @SideOnly(Side.CLIENT)
   public void getSubItems(Item par1, CreativeTabs par2CreativeTabs, List par3List) {
     for (int j = 0; j < 2; ++j) {
       par3List.add(new ItemStack(par1, 1, j));
@@ -82,7 +81,7 @@ public class ItemGliderWing extends Item implements IResourceTooltipProvider {
     return getUnlocalizedName(itemStack);
   }
 
- 
+
 //  @Override
 //  @SideOnly(Side.CLIENT)
 //  public void addInformation(ItemStack par1ItemStack, EntityPlayer par2EntityPlayer, List par3List, boolean par4) {
@@ -91,5 +90,5 @@ public class ItemGliderWing extends Item implements IResourceTooltipProvider {
 //    }
 //
 //  }
-  
+
 }

--- a/src/main/java/crazypants/enderio/item/darksteel/SoundRenderer.java
+++ b/src/main/java/crazypants/enderio/item/darksteel/SoundRenderer.java
@@ -8,25 +8,28 @@ import net.minecraft.entity.Entity;
 
 import org.lwjgl.opengl.GL11;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.gui.IconEIO;
 
+@SideOnly(Side.CLIENT)
 public class SoundRenderer extends RenderEntity {
 
   @Override
   public void doRender(Entity entity, double x, double y, double z, float p_76986_8_, float p_76986_9_) {
 
     SoundEntity se = ((SoundEntity) entity);
-    
+
     GL11.glPushAttrib(GL11.GL_ENABLE_BIT);
     GL11.glDisable(GL11.GL_DEPTH_TEST);
     GL11.glDisable(GL11.GL_LIGHTING);
     GL11.glEnable(GL11.GL_BLEND);
     GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
-    
+
     OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, 240, 240);
 
     float alpha = 0.5f;
-    
+
     GL11.glColor4f(1, 1, 1, alpha);
 
     float scale = se.lifeSpan / 20f;
@@ -36,9 +39,9 @@ public class SoundRenderer extends RenderEntity {
     GL11.glTranslatef((float) x, (float) y, (float) z);
     GL11.glRotatef(-player.rotationYaw, 0.0F, 1.0F, 0.0F);
     GL11.glRotatef(player.rotationPitch, 1.0F, 0.0F, 0.0F);
-    
+
     double size = 0.5 * se.lifeSpan / 20f;
-    
+
     IconEIO.SOUND.renderIcon(-size/2, -size/2, size,size,0,true,true);
 
     GL11.glPopAttrib();

--- a/src/main/java/crazypants/enderio/item/skull/BlockEndermanSkull.java
+++ b/src/main/java/crazypants/enderio/item/skull/BlockEndermanSkull.java
@@ -1,6 +1,5 @@
 package crazypants.enderio.item.skull;
 
-import cpw.mods.fml.common.Optional;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.EntityLivingBase;
@@ -9,12 +8,13 @@ import net.minecraft.util.IIcon;
 import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
+import thaumcraft.api.crafting.IInfusionStabiliser;
+import cpw.mods.fml.common.Optional;
 import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.BlockEio;
 import crazypants.enderio.ModObject;
-import thaumcraft.api.crafting.IInfusionStabiliser;
 
 @Optional.Interface(iface = "thaumcraft.api.crafting.IInfusionStabiliser", modid = "Thaumcraft")
 public class BlockEndermanSkull extends BlockEio implements IInfusionStabiliser {
@@ -22,22 +22,22 @@ public class BlockEndermanSkull extends BlockEio implements IInfusionStabiliser 
   public static int renderId = -1;
 
   public enum SkullType {
-    
+
     BASE("base",false),
     REANIMATED("reanimated",true),
     TORMENTED("tormented",false),
     REANIMATED_TORMENTED("reanimatedTormented",true);
-    
+
     final String name;
     final boolean showEyes;
-    
-    
+
+
     SkullType(String name, boolean showEyes) {
       this.name = name;
       this.showEyes = showEyes;
     }
   }
-  
+
   public static BlockEndermanSkull create() {
     BlockEndermanSkull res = new BlockEndermanSkull();
     res.init();
@@ -53,18 +53,19 @@ public class BlockEndermanSkull extends BlockEio implements IInfusionStabiliser 
     super(ModObject.blockEndermanSkull.unlocalisedName, TileEndermanSkull.class, Material.circuits);
     setBlockBounds(0.25F, 0.0F, 0.25F, 0.75F, 0.5F, 0.75F);
   }
-  
-  
+
+
 
   @Override
   protected void init() {
-    GameRegistry.registerBlock(this, ItemEndermanSkull.class, name);    
-    GameRegistry.registerTileEntity(teClass, name + "TileEntity");    
+    GameRegistry.registerBlock(this, ItemEndermanSkull.class, name);
+    GameRegistry.registerTileEntity(teClass, name + "TileEntity");
   }
 
 
 
   @Override
+  @SideOnly(Side.CLIENT)
   public void registerBlockIcons(IIconRegister iIconRegister) {
     frontIcon = iIconRegister.registerIcon("enderio:endermanSkullFront");
     frontIconEyes = iIconRegister.registerIcon("enderio:endermanSkullFrontEyes");
@@ -86,18 +87,22 @@ public class BlockEndermanSkull extends BlockEio implements IInfusionStabiliser 
     return sideIcon;
   }
 
+  @Override
   public int getRenderType() {
     return renderId;
   }
 
+  @Override
   public boolean isOpaqueCube() {
     return false;
   }
 
+  @Override
   public boolean renderAsNormalBlock() {
     return false;
   }
 
+  @Override
   @SideOnly(Side.CLIENT)
   public String getItemIconName() {
     return "enderio:endermanSkull";
@@ -105,9 +110,9 @@ public class BlockEndermanSkull extends BlockEio implements IInfusionStabiliser 
 
   @Override
   public void onBlockPlacedBy(World world, int x, int y, int z, EntityLivingBase player, ItemStack stack) {
-    
-    int inc = MathHelper.floor_double((double)(player.rotationYaw * 16.0F / 360.0F) + 0.5D) & 15;
-    float facingYaw = -22.5f * inc;   
+
+    int inc = MathHelper.floor_double(player.rotationYaw * 16.0F / 360.0F + 0.5D) & 15;
+    float facingYaw = -22.5f * inc;
     TileEndermanSkull te = (TileEndermanSkull) world.getTileEntity(x, y, z);
     te.setYaw(facingYaw);
     if(world.isRemote) {

--- a/src/main/java/crazypants/enderio/item/skull/ItemEndermanSkull.java
+++ b/src/main/java/crazypants/enderio/item/skull/ItemEndermanSkull.java
@@ -2,16 +2,16 @@ package crazypants.enderio.item.skull;
 
 import java.util.List;
 
-import crazypants.enderio.EnderIOTab;
-import crazypants.enderio.item.skull.BlockEndermanSkull.SkullType;
-import crazypants.enderio.material.BlockFusedQuartz;
 import net.minecraft.block.Block;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.item.Item;
-import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemBlockWithMetadata;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.MathHelper;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import crazypants.enderio.EnderIOTab;
+import crazypants.enderio.item.skull.BlockEndermanSkull.SkullType;
 
 public class ItemEndermanSkull extends ItemBlockWithMetadata {
 
@@ -19,7 +19,7 @@ public class ItemEndermanSkull extends ItemBlockWithMetadata {
     super(block, block);
     setCreativeTab(EnderIOTab.tabEnderIO);
   }
-  
+
   @Override
   public String getUnlocalizedName(ItemStack par1ItemStack) {
     int meta = par1ItemStack.getItemDamage();
@@ -29,6 +29,7 @@ public class ItemEndermanSkull extends ItemBlockWithMetadata {
 
   @Override
   @SuppressWarnings({ "rawtypes", "unchecked" })
+  @SideOnly(Side.CLIENT)
   public void getSubItems(Item par1, CreativeTabs par2CreativeTabs, List par3List) {
     for (int j = 0; j < SkullType.values().length; ++j) {
       if(!SkullType.values()[j].showEyes) {

--- a/src/main/java/crazypants/enderio/machine/alloy/BlockAlloySmelter.java
+++ b/src/main/java/crazypants/enderio/machine/alloy/BlockAlloySmelter.java
@@ -6,6 +6,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.World;
 import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.GuiHandler;
 import crazypants.enderio.ModObject;
 import crazypants.enderio.machine.AbstractMachineBlock;
@@ -31,6 +32,7 @@ public class BlockAlloySmelter extends AbstractMachineBlock<TileAlloySmelter> {
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public void registerBlockIcons(IIconRegister iIconRegister) {
     super.registerBlockIcons(iIconRegister);
     vanillaSmeltingOn = iIconRegister.registerIcon("enderio:furnaceSmeltingOn");

--- a/src/main/java/crazypants/enderio/machine/attractor/ObeliskRenderer.java
+++ b/src/main/java/crazypants/enderio/machine/attractor/ObeliskRenderer.java
@@ -14,7 +14,6 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.client.renderer.Tessellator;
-import net.minecraft.client.renderer.entity.RenderItem;
 import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.entity.item.EntityItem;
@@ -29,6 +28,8 @@ import net.minecraftforge.client.IItemRenderer;
 import org.lwjgl.opengl.GL11;
 
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.EnderIO;
 import crazypants.render.BoundingBox;
 import crazypants.render.CubeRenderer;
@@ -38,12 +39,13 @@ import crazypants.vecmath.Vector3d;
 import crazypants.vecmath.Vector3f;
 import crazypants.vecmath.Vertex;
 
+@SideOnly(Side.CLIENT)
 public class ObeliskRenderer<T extends TileEntity> extends TileEntitySpecialRenderer implements ISimpleBlockRenderingHandler, IItemRenderer {
 
   private VertXForm xform = new VertXForm();
   private VertXForm2 xform2 = new VertXForm2();
   private ItemStack floatingStack;
-  
+
   private Random rand = new Random();
 
   public ObeliskRenderer(ItemStack itemStack) {
@@ -86,7 +88,7 @@ public class ObeliskRenderer<T extends TileEntity> extends TileEntitySpecialRend
     default:
       break;
     }
-    
+
     renderInventoryBlock(EnderIO.blockAttractor, item.getItemDamage(), 0, (RenderBlocks) data[0]);
     Timer t = RenderUtil.getTimer();
     renderItemStack(null, Minecraft.getMinecraft().theWorld, 0, 0, 0, t.renderPartialTicks);
@@ -106,18 +108,18 @@ public class ObeliskRenderer<T extends TileEntity> extends TileEntitySpecialRend
     int l1 = l % 65536;
     int l2 = l / 65536;
     Tessellator.instance.setColorOpaque_F(f, f, f);
-    OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, (float) l1, (float) l2);
+    OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, l1, l2);
 
     renderItemStack((T) te, world, x, y, z, tick);
   }
 
   private void renderItemStack(T te, World world, double x, double y, double z, float tick) {
     if(ei == null) {
-      ei = new EntityItem(world, 0, 0, 0, getFloatingItem((T) te));
+      ei = new EntityItem(world, 0, 0, 0, getFloatingItem(te));
     }
 
     ei.setEntityItemStack(getFloatingItem(te));
-    ei.hoverStart = (float) world.getTotalWorldTime() * 0.05f + (tick * 0.05f);
+    ei.hoverStart = world.getTotalWorldTime() * 0.05f + (tick * 0.05f);
 
     glPushMatrix();
     glTranslated(x + 0.5, y + 0.7, z + 0.5);
@@ -136,7 +138,7 @@ public class ObeliskRenderer<T extends TileEntity> extends TileEntitySpecialRend
     RenderManager.instance.renderEntityWithPosYaw(ei, 0.0D, 0.0D, 0.0D, 0.0F, 0.0F);
     glPopMatrix();
   }
-  
+
   /**
    * @param te CAN BE NULL
    */
@@ -161,7 +163,7 @@ public class ObeliskRenderer<T extends TileEntity> extends TileEntitySpecialRend
     BoundingBox bb = BoundingBox.UNIT_CUBE;
 
     Tessellator.instance.addTranslation(x, y, z);
-    
+
     IIcon icon = EnderIO.blockAttractor.getOnIcon();
     if(world != null) {
       icon = block.getIcon(world, x, y, z, 0);

--- a/src/main/java/crazypants/enderio/machine/buffer/BlockBuffer.java
+++ b/src/main/java/crazypants/enderio/machine/buffer/BlockBuffer.java
@@ -1,7 +1,5 @@
 package crazypants.enderio.machine.buffer;
 
-import java.util.ArrayList;
-
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.EntityLivingBase;
@@ -13,9 +11,6 @@ import net.minecraft.util.IIcon;
 import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
-
-import com.google.common.collect.Lists;
-
 import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
@@ -94,11 +89,13 @@ public class BlockBuffer extends AbstractMachineBlock<TileBuffer> implements IFa
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public IIcon getIcon(int blockSide, int blockMeta) {
     return blockSide > 1 ? textures[blockMeta] : super.getIcon(blockSide, blockMeta);
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public IIcon getIcon(IBlockAccess world, int x, int y, int z, int blockSide) {
     TileEntity te = world.getTileEntity(x, y, z);
     if(te instanceof TileBuffer) {

--- a/src/main/java/crazypants/enderio/machine/buffer/BlockItemBuffer.java
+++ b/src/main/java/crazypants/enderio/machine/buffer/BlockItemBuffer.java
@@ -10,6 +10,8 @@ import net.minecraft.item.ItemBlockWithMetadata;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.EnderIO;
 import crazypants.enderio.ModObject;
 
@@ -20,11 +22,11 @@ public class BlockItemBuffer extends ItemBlockWithMetadata {
     POWER(false, true, false),
     OMNI(true, true, false),
     CREATIVE(true, true, true);
-    
+
     final boolean hasInventory;
     final boolean hasPower;
     final boolean isCreative;
-    
+
     private Type(boolean hasInventory, boolean hasPower, boolean isCreative) {
       this.hasInventory = hasInventory;
       this.hasPower = hasPower;
@@ -34,7 +36,7 @@ public class BlockItemBuffer extends ItemBlockWithMetadata {
     public static Type get(TileBuffer buffer) {
       return !buffer.hasPower() ? ITEM : !buffer.hasInventory() ? POWER : !buffer.isCreative() ? OMNI : CREATIVE;
     }
-    
+
     public String getUnlocalizedName() {
       return "tile." + ModObject.blockBuffer.unlocalisedName + "." + name().toLowerCase();
     }
@@ -43,24 +45,25 @@ public class BlockItemBuffer extends ItemBlockWithMetadata {
 		return new ItemStack(EnderIO.blockBuffer, 1, type.ordinal());
 	}
   }
-  
+
   public BlockItemBuffer(Block block) {
     super(block, block);
   }
-  
+
   @SuppressWarnings({ "rawtypes", "unchecked" })
   @Override
+  @SideOnly(Side.CLIENT)
   public void getSubItems(Item item, CreativeTabs tab, List list) {
     for (Type type : Type.values()) {
       list.add(new ItemStack(item, 1, type.ordinal()));
     }
   }
-  
+
   @Override
   public String getUnlocalizedName(ItemStack stack) {
     return Type.values()[stack.getItemDamage()].getUnlocalizedName();
   }
-  
+
   @Override
   public boolean placeBlockAt(ItemStack stack, EntityPlayer player, World world, int x, int y, int z, int side, float hitX, float hitY, float hitZ, int metadata) {
     super.placeBlockAt(stack, player, world, x, y, z, side, hitX, hitY, hitZ, metadata);

--- a/src/main/java/crazypants/enderio/machine/capbank/BlockCapBank.java
+++ b/src/main/java/crazypants/enderio/machine/capbank/BlockCapBank.java
@@ -272,6 +272,7 @@ public class BlockCapBank extends BlockEio implements IGuiHandler, IAdvancedTool
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public boolean shouldSideBeRendered(IBlockAccess par1IBlockAccess, int par2, int par3, int par4, int par5) {
     Block i1 = par1IBlockAccess.getBlock(par2, par3, par4);
     return i1 == this ? false : super.shouldSideBeRendered(par1IBlockAccess, par2, par3, par4, par5);

--- a/src/main/java/crazypants/enderio/machine/capbank/render/CapBankRenderer.java
+++ b/src/main/java/crazypants/enderio/machine/capbank/render/CapBankRenderer.java
@@ -18,6 +18,8 @@ import net.minecraftforge.common.util.ForgeDirection;
 import org.lwjgl.opengl.GL11;
 
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.EnderIO;
 import crazypants.enderio.machine.capbank.BlockCapBank;
 import crazypants.enderio.machine.capbank.CapBankType;
@@ -32,6 +34,7 @@ import crazypants.render.CubeRenderer;
 import crazypants.render.CustomCubeRenderer;
 import crazypants.render.RenderUtil;
 
+@SideOnly(Side.CLIENT)
 public class CapBankRenderer extends TileEntitySpecialRenderer implements ISimpleBlockRenderingHandler, IItemRenderer {
 
   private ConnectedTextureRenderer connectedTexRenderer;
@@ -86,7 +89,7 @@ public class CapBankRenderer extends TileEntitySpecialRenderer implements ISimpl
     return BlockCapBank.renderId;
   }
 
-  //------- Item 
+  //------- Item
   @Override
   public boolean handleRenderType(ItemStack item, ItemRenderType type) {
     return true;

--- a/src/main/java/crazypants/enderio/machine/crusher/BlockCrusher.java
+++ b/src/main/java/crazypants/enderio/machine/crusher/BlockCrusher.java
@@ -7,17 +7,17 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.GuiHandler;
 import crazypants.enderio.ModObject;
 import crazypants.enderio.machine.AbstractMachineBlock;
-import crazypants.enderio.machine.generator.stirling.TileEntityStirlingGenerator;
 import crazypants.enderio.network.PacketHandler;
 
 public class BlockCrusher extends AbstractMachineBlock {
 
   public static BlockCrusher create() {
     PacketHandler.INSTANCE.registerMessage(PacketGrindingBall.class, PacketGrindingBall.class, PacketHandler.nextID(), Side.CLIENT);
-    
+
     BlockCrusher res = new BlockCrusher();
     res.init();
     return res;
@@ -59,8 +59,9 @@ public class BlockCrusher extends AbstractMachineBlock {
     }
     return "enderio:crusherFront";
   }
-  
+
   @Override
+  @SideOnly(Side.CLIENT)
   public void randomDisplayTick(World world, int x, int y, int z, Random rand) {
     TileCrusher te = (TileCrusher) world.getTileEntity(x, y, z);
     if(te != null && te.isActive()) {
@@ -73,7 +74,7 @@ public class BlockCrusher extends AbstractMachineBlock {
         double v = 0.05;
         double vx = 0;
         double vz = 0;
-        
+
         if(front == ForgeDirection.NORTH || front == ForgeDirection.SOUTH) {
           px += world.rand.nextFloat() * 0.8 - 0.4;
           vz += front == ForgeDirection.NORTH ? -v : v;

--- a/src/main/java/crazypants/enderio/machine/enchanter/EnchanterModelRenderer.java
+++ b/src/main/java/crazypants/enderio/machine/enchanter/EnchanterModelRenderer.java
@@ -12,8 +12,11 @@ import net.minecraftforge.common.util.ForgeDirection;
 
 import org.lwjgl.opengl.GL11;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.render.RenderUtil;
 
+@SideOnly(Side.CLIENT)
 public class EnchanterModelRenderer extends TileEntitySpecialRenderer implements IItemRenderer {
 
   private static final String TEXTURE = "enderio:models/BookStand.png";
@@ -31,11 +34,11 @@ public class EnchanterModelRenderer extends TileEntitySpecialRenderer implements
     int l1 = l % 65536;
     int l2 = l / 65536;
     Tessellator.instance.setColorOpaque_F(f, f, f);
-    OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, (float) l1, (float) l2);
+    OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, l1, l2);
 
     GL11.glPushMatrix();
     GL11.glTranslatef((float) x, (float) y, (float) z);
-    renderModel(gen.getFacing());    
+    renderModel(gen.getFacing());
     GL11.glPopMatrix();
   }
 

--- a/src/main/java/crazypants/enderio/machine/farm/BlockFarmStation.java
+++ b/src/main/java/crazypants/enderio/machine/farm/BlockFarmStation.java
@@ -76,7 +76,7 @@ public class BlockFarmStation extends AbstractMachineBlock<TileFarmStation> {
   public boolean shouldSideBeRendered(IBlockAccess p_149646_1_, int p_149646_2_, int p_149646_3_, int p_149646_4_, int p_149646_5_) {
     return true;
   }
-  
+
   @Override
   public int getLightOpacity() {
     return 7;
@@ -107,6 +107,7 @@ public class BlockFarmStation extends AbstractMachineBlock<TileFarmStation> {
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public void randomDisplayTick(World world, int x, int y, int z, Random rand) {
   }
 

--- a/src/main/java/crazypants/enderio/machine/farm/FarmingStationSpecialRenderer.java
+++ b/src/main/java/crazypants/enderio/machine/farm/FarmingStationSpecialRenderer.java
@@ -5,10 +5,13 @@ import static org.lwjgl.opengl.GL11.glDisable;
 import static org.lwjgl.opengl.GL11.glEnable;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.tileentity.TileEntity;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.config.Config;
 import crazypants.render.RenderUtil;
 import crazypants.vecmath.Vector3f;
 
+@SideOnly(Side.CLIENT)
 public class FarmingStationSpecialRenderer extends TileEntitySpecialRenderer{
 
   private void renderFarmStationAt(TileFarmStation tile, double x, double y, double z, float partialTickTime) {
@@ -17,13 +20,13 @@ public class FarmingStationSpecialRenderer extends TileEntitySpecialRenderer{
     if ("".equals(toRender) || Config.disableFarmNotification) {
       return;
     }
-    
+
     glDisable(GL_LIGHTING);
     RenderUtil.drawBillboardedText(new Vector3f(x + 0.5, y + 1.5, z + 0.5), toRender, 0.25f);
     glEnable(GL_LIGHTING);
 
-  }  
-  
+  }
+
   @Override
   public void renderTileEntityAt(TileEntity tile, double x, double y, double z, float partialTickTime) {
     if (tile instanceof TileFarmStation) {

--- a/src/main/java/crazypants/enderio/machine/generator/combustion/BlockCombustionGenerator.java
+++ b/src/main/java/crazypants/enderio/machine/generator/combustion/BlockCombustionGenerator.java
@@ -10,6 +10,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.FluidStack;
 import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.GuiHandler;
 import crazypants.enderio.ModObject;
 import crazypants.enderio.machine.AbstractMachineBlock;
@@ -24,7 +25,7 @@ public class BlockCombustionGenerator extends AbstractMachineBlock<TileCombustio
 
   public static BlockCombustionGenerator create() {
     PacketHandler.INSTANCE.registerMessage(PacketCombustionTank.class, PacketCombustionTank.class, PacketHandler.nextID(), Side.CLIENT);
-    
+
     BlockCombustionGenerator gen = new BlockCombustionGenerator();
     gen.init();
     return gen;
@@ -125,6 +126,7 @@ public class BlockCombustionGenerator extends AbstractMachineBlock<TileCombustio
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public void randomDisplayTick(World world, int x, int y, int z, Random rand) {
     // If active, randomly throw some smoke around
     if(isActive(world, x, y, z)) {

--- a/src/main/java/crazypants/enderio/machine/generator/combustion/CombustionGeneratorModelRenderer.java
+++ b/src/main/java/crazypants/enderio/machine/generator/combustion/CombustionGeneratorModelRenderer.java
@@ -12,65 +12,68 @@ import net.minecraftforge.common.util.ForgeDirection;
 
 import org.lwjgl.opengl.GL11;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.render.RenderUtil;
 
+@SideOnly(Side.CLIENT)
 public class CombustionGeneratorModelRenderer extends TileEntitySpecialRenderer implements IItemRenderer {
 
   private static final String TEXTURE = "enderio:models/combustionGenerator.png";
-  
+
   private CombustionGeneratorModel model = new CombustionGeneratorModel();
-  
+
   @Override
   public void renderTileEntityAt(TileEntity te, double x, double y, double z, float tick) {
-    
+
     World world = te.getWorldObj();
     TileCombustionGenerator gen = (TileCombustionGenerator)te;
 //    GL11.glEnable(GL11.GL_LIGHTING);
 //    GL11.glEnable(GL12.GL_RESCALE_NORMAL);
 //    GL11.glDisable(GL11.GL_CULL_FACE);
 
-    
-    
-    
+
+
+
     float f = world.getBlockLightValue(te.xCoord, te.yCoord, te.zCoord);
     int l = world.getLightBrightnessForSkyBlocks(te.xCoord, te.yCoord, te.zCoord, 0);
     int l1 = l % 65536;
     int l2 = l / 65536;
     Tessellator.instance.setColorOpaque_F(f, f, f);
-    OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, (float)l1, (float)l2); 
-    
-    
+    OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, l1, l2);
+
+
     GL11.glPushMatrix();
     GL11.glTranslatef((float)x, (float)y, (float)z);
-    renderModel(gen.facing);       
+    renderModel(gen.facing);
     GL11.glPopMatrix();
   }
 
   private void renderModel(int facing) {
-    
+
     GL11.glPushMatrix();
-        
-    GL11.glTranslatef(0.5F, 1, 0.5F);    
+
+    GL11.glTranslatef(0.5F, 1, 0.5F);
     GL11.glRotatef(180F, 1F, 0F, 0F);
     GL11.glScalef(1, 0.667f, 1);
-    
+
     ForgeDirection dir = ForgeDirection.getOrientation(facing);
     if(dir == ForgeDirection.SOUTH) {
       facing = 0;
-      
+
     } else if(dir == ForgeDirection.WEST) {
       facing = -1;
-    }    
+    }
     GL11.glRotatef(facing * -90F, 0F, 1F, 0F);
 
     RenderUtil.bindTexture(TEXTURE);
     model.render((Entity)null, 0.0F, 0.0F, -0.1F, 0.0F, 0.0F, 0.0625F);
-    
-    GL11.glTranslatef(-0.5F, -1, -0.5F); 
+
+    GL11.glTranslatef(-0.5F, -1, -0.5F);
     GL11.glPopMatrix();
-    
+
   }
-  
+
   @Override
   public boolean handleRenderType(ItemStack item, ItemRenderType type) {
     return true;
@@ -106,10 +109,10 @@ public class CombustionGeneratorModelRenderer extends TileEntitySpecialRenderer 
 
   private void renderItem(float x, float y, float z) {
     GL11.glPushMatrix();
-    GL11.glTranslatef(x, y, z);   
+    GL11.glTranslatef(x, y, z);
     renderModel(ForgeDirection.NORTH.ordinal());
     GL11.glPopMatrix();
   }
- 
+
 
 }

--- a/src/main/java/crazypants/enderio/machine/generator/combustion/CombustionGeneratorRenderer.java
+++ b/src/main/java/crazypants/enderio/machine/generator/combustion/CombustionGeneratorRenderer.java
@@ -16,6 +16,8 @@ import net.minecraftforge.fluids.FluidTank;
 import org.lwjgl.opengl.GL11;
 
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.EnderIO;
 import crazypants.enderio.config.Config;
 import crazypants.enderio.machine.AbstractMachineBlock;
@@ -30,6 +32,7 @@ import crazypants.util.ForgeDirectionOffsets;
 import crazypants.vecmath.Vector3d;
 import crazypants.vecmath.Vertex;
 
+@SideOnly(Side.CLIENT)
 public class CombustionGeneratorRenderer extends TileEntitySpecialRenderer implements ISimpleBlockRenderingHandler {
 
   private CustomCubeRenderer ccr = new CustomCubeRenderer();
@@ -60,7 +63,7 @@ public class CombustionGeneratorRenderer extends TileEntitySpecialRenderer imple
     boolean scaleX = facing != 4 && facing != 5;
     float scx;
     float scz;
-    
+
     IIcon override = renderer.overrideBlockTexture;
 
     //middle chunk
@@ -106,12 +109,12 @@ public class CombustionGeneratorRenderer extends TileEntitySpecialRenderer imple
       tex = EnderIO.blockCombustionGenerator.getIcon(4,0);
     } else {
       tex = EnderIO.blockFusedQuartz.getDefaultFrameIcon(0);
-    } 
-    
+    }
+
     if (override != null) {
       tex = override;
     }
-    
+
     TranslatedCubeRenderer.instance.renderBoundingBox(x, y, z, block, bb, vt, tex, world != null);
 
     bb = bb.translate(-tx * 2, 0, -tz * 2);

--- a/src/main/java/crazypants/enderio/machine/generator/zombie/BubbleFX.java
+++ b/src/main/java/crazypants/enderio/machine/generator/zombie/BubbleFX.java
@@ -2,7 +2,10 @@ package crazypants.enderio.machine.generator.zombie;
 
 import net.minecraft.client.particle.EntityBubbleFX;
 import net.minecraft.world.World;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 
+@SideOnly(Side.CLIENT)
 public class BubbleFX extends EntityBubbleFX {
 
   private final double yLimit;

--- a/src/main/java/crazypants/enderio/machine/generator/zombie/ZombieGeneratorRenderer.java
+++ b/src/main/java/crazypants/enderio/machine/generator/zombie/ZombieGeneratorRenderer.java
@@ -14,12 +14,15 @@ import net.minecraftforge.fluids.FluidTank;
 
 import org.lwjgl.opengl.GL11;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.render.BoundingBox;
 import crazypants.render.CubeRenderer;
 import crazypants.render.RenderUtil;
 import crazypants.util.ForgeDirectionOffsets;
 import crazypants.vecmath.Vector3d;
 
+@SideOnly(Side.CLIENT)
 public class ZombieGeneratorRenderer extends TileEntitySpecialRenderer implements IItemRenderer {
 
   private static final String TEXTURE = "enderio:models/ZombieJar.png";
@@ -70,13 +73,13 @@ public class ZombieGeneratorRenderer extends TileEntitySpecialRenderer implement
       double scaleX = absFac.x == 0 ? 0.95 : 1 - facingOffset / 2;
       double scaleY = 0.85 * fullness;
       double scaleZ = absFac.z == 0 ? 0.95 : 1 - facingOffset / 2;
-      
+
       bb = bb.scale(scaleX, 0.85 * fullness, scaleZ);
-      
+
       float ty = -(0.85f - (bb.maxY - bb.minY)) / 2;
       Vector3d transOffset = ForgeDirectionOffsets.offsetScaled(facingDir, -facingOffset);
       bb = bb.translate((float) transOffset.x, ty, (float) transOffset.z);
-      
+
       int brightness;
       if(gen.getWorldObj() == null) {
         brightness = 15 << 20 | 15 << 4;
@@ -84,13 +87,13 @@ public class ZombieGeneratorRenderer extends TileEntitySpecialRenderer implement
         brightness = gen.getWorldObj().getLightBrightnessForSkyBlocks(gen.xCoord, gen.yCoord, gen.zCoord, 0);
       }
       tes.setBrightness(brightness);
-      
+
       CubeRenderer.render(bb, icon);
 
       GL11.glPushAttrib(GL11.GL_ENABLE_BIT);
       GL11.glEnable(GL11.GL_BLEND);
       GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
-      GL11.glDisable(GL11.GL_LIGHTING);           
+      GL11.glDisable(GL11.GL_LIGHTING);
       GL11.glDisable(GL11.GL_CULL_FACE);
       GL11.glDepthMask(false);
       tes.draw();

--- a/src/main/java/crazypants/enderio/machine/hypercube/BlockHyperCube.java
+++ b/src/main/java/crazypants/enderio/machine/hypercube/BlockHyperCube.java
@@ -5,7 +5,6 @@ import java.util.ArrayList;
 import java.util.Random;
 import java.util.UUID;
 
-import crazypants.util.PlayerUtil;
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.EntityLivingBase;
@@ -23,6 +22,7 @@ import net.minecraftforge.common.util.ForgeDirection;
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.network.IGuiHandler;
 import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.BlockEio;
 import crazypants.enderio.EnderIO;
 import crazypants.enderio.GuiHandler;
@@ -32,7 +32,7 @@ import crazypants.enderio.machine.hypercube.TileHyperCube.IoMode;
 import crazypants.enderio.machine.hypercube.TileHyperCube.SubChannel;
 import crazypants.enderio.network.PacketHandler;
 import crazypants.enderio.power.PowerHandlerUtil;
-import crazypants.enderio.tool.ToolUtil;
+import crazypants.util.PlayerUtil;
 import crazypants.util.Util;
 
 public class BlockHyperCube extends BlockEio implements IGuiHandler, IResourceTooltipProvider {
@@ -79,6 +79,7 @@ public class BlockHyperCube extends BlockEio implements IGuiHandler, IResourceTo
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public void registerBlockIcons(IIconRegister IIconRegister) {
     blockIcon = IIconRegister.registerIcon("enderio:tesseractPortal");
   }

--- a/src/main/java/crazypants/enderio/machine/hypercube/HyperCubeRenderer.java
+++ b/src/main/java/crazypants/enderio/machine/hypercube/HyperCubeRenderer.java
@@ -11,12 +11,15 @@ import net.minecraftforge.client.IItemRenderer;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL12;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.EnderIO;
 import crazypants.enderio.config.Config;
 import crazypants.render.BoundingBox;
 import crazypants.render.CubeRenderer;
 import crazypants.render.RenderUtil;
 
+@SideOnly(Side.CLIENT)
 public class HyperCubeRenderer extends TileEntitySpecialRenderer implements IItemRenderer {
 
   private IModel model;

--- a/src/main/java/crazypants/enderio/machine/killera/KillerJoeRenderer.java
+++ b/src/main/java/crazypants/enderio/machine/killera/KillerJoeRenderer.java
@@ -1,10 +1,8 @@
 package crazypants.enderio.machine.killera;
 
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.ItemRenderer;
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.Tessellator;
-import net.minecraft.client.renderer.entity.RenderItem;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.entity.Entity;
 import net.minecraft.init.Items;
@@ -14,12 +12,13 @@ import net.minecraft.util.IIcon;
 import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 import net.minecraftforge.client.IItemRenderer;
-import net.minecraftforge.common.util.FakePlayer;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.FluidTank;
 
 import org.lwjgl.opengl.GL11;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.machine.generator.zombie.ModelZombieJar;
 import crazypants.render.BoundingBox;
 import crazypants.render.CubeRenderer;
@@ -27,6 +26,7 @@ import crazypants.render.RenderUtil;
 import crazypants.util.ForgeDirectionOffsets;
 import crazypants.vecmath.Vector3d;
 
+@SideOnly(Side.CLIENT)
 public class KillerJoeRenderer extends TileEntitySpecialRenderer implements IItemRenderer {
 
   private static final String TEXTURE = "enderio:models/KillerJoe.png";
@@ -47,7 +47,7 @@ public class KillerJoeRenderer extends TileEntitySpecialRenderer implements IIte
     int l1 = l % 65536;
     int l2 = l / 65536;
     Tessellator.instance.setColorOpaque_F(f, f, f);
-    OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, (float) l1, (float) l2);
+    OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, l1, l2);
 
     GL11.glPushMatrix();
     GL11.glTranslatef((float) x, (float) y, (float) z);
@@ -140,10 +140,10 @@ public class KillerJoeRenderer extends TileEntitySpecialRenderer implements IIte
       GL11.glPushAttrib(GL11.GL_ENABLE_BIT);
       GL11.glEnable(GL11.GL_BLEND);
       GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
-      GL11.glDisable(GL11.GL_LIGHTING);     
+      GL11.glDisable(GL11.GL_LIGHTING);
       GL11.glDepthMask(false);
-      GL11.glColor3f(1, 1, 1);      
-      
+      GL11.glColor3f(1, 1, 1);
+
       tes.draw();
       GL11.glDepthMask(true);
       GL11.glPopAttrib();

--- a/src/main/java/crazypants/enderio/machine/light/BlockElectricLight.java
+++ b/src/main/java/crazypants/enderio/machine/light/BlockElectricLight.java
@@ -1,12 +1,7 @@
 package crazypants.enderio.machine.light;
 
-import java.util.ArrayList;
-import java.util.Random;
-
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.texture.IIconRegister;
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.AxisAlignedBB;
@@ -22,8 +17,6 @@ import crazypants.enderio.BlockEio;
 import crazypants.enderio.ModObject;
 import crazypants.enderio.TileEntityEio;
 import crazypants.enderio.api.redstone.IRedstoneConnectable;
-import crazypants.enderio.api.tool.ITool;
-import crazypants.enderio.tool.ToolUtil;
 import crazypants.vecmath.Vector3f;
 
 public class BlockElectricLight extends BlockEio implements IRedstoneConnectable {
@@ -63,6 +56,7 @@ public class BlockElectricLight extends BlockEio implements IRedstoneConnectable
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public void registerBlockIcons(IIconRegister iIconRegister) {
     blockIcon = iIconRegister.registerIcon("enderio:blockElectricLightFace");
     blockIconOff = iIconRegister.registerIcon("enderio:blockElectricLightFaceOff");
@@ -215,7 +209,7 @@ public class BlockElectricLight extends BlockEio implements IRedstoneConnectable
   }
 
   /* IRedstoneConnectable */
-  
+
   @Override
   public boolean shouldRedstoneConduitConnect(World world, int x, int y, int z, ForgeDirection from) {
     return true;

--- a/src/main/java/crazypants/enderio/machine/light/BlockItemElectricLight.java
+++ b/src/main/java/crazypants/enderio/machine/light/BlockItemElectricLight.java
@@ -12,6 +12,8 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.EnderIOTab;
 import crazypants.enderio.gui.IResourceTooltipProvider;
 
@@ -24,21 +26,21 @@ public class BlockItemElectricLight extends ItemBlockWithMetadata implements IRe
     BASIC_INV("item.itemLightInverted", true, false, false),
     WIRELESS("item.itemWirelessLight", false, true, true),
     WIRELESS_INV("item.itemWirelessLightInverted", true, true, true);
-    
+
     final String unlocName;
     final boolean isInverted;
     final boolean isPowered;
     final boolean isWireless;
-    
+
     private Type(String unlocName, boolean isInverted, boolean isPowered, boolean isWireless) {
       this.unlocName = unlocName;
       this.isInverted = isInverted;
       this.isPowered = isPowered;
       this.isWireless = isWireless;
     }
-    
+
   }
-  
+
   public BlockItemElectricLight(Block block) {
     super(block, block);
     setCreativeTab(EnderIOTab.tabEnderIO);
@@ -53,6 +55,7 @@ public class BlockItemElectricLight extends ItemBlockWithMetadata implements IRe
 
   @Override
   @SuppressWarnings({ "rawtypes", "unchecked" })
+  @SideOnly(Side.CLIENT)
   public void getSubItems(Item par1, CreativeTabs par2CreativeTabs, List par3List) {
     for(Type type : Type.values()) {
       par3List.add(new ItemStack(this,1,type.ordinal()));
@@ -68,7 +71,7 @@ public class BlockItemElectricLight extends ItemBlockWithMetadata implements IRe
       ForgeDirection onFace = ForgeDirection.values()[side].getOpposite();
       TileEntity te = world.getTileEntity(x, y, z);
       if(te instanceof TileElectricLight) {
-        TileElectricLight el = ((TileElectricLight) te); 
+        TileElectricLight el = ((TileElectricLight) te);
         el.setFace(onFace);
         Type t= Type.values()[metadata];
         el.setInverted(t.isInverted);
@@ -80,7 +83,7 @@ public class BlockItemElectricLight extends ItemBlockWithMetadata implements IRe
   }
 
   @Override
-  public String getUnlocalizedNameForTooltip(ItemStack itemStack) {    
+  public String getUnlocalizedNameForTooltip(ItemStack itemStack) {
     return getUnlocalizedName(itemStack);
   }
 }

--- a/src/main/java/crazypants/enderio/machine/light/BlockLightNode.java
+++ b/src/main/java/crazypants/enderio/machine/light/BlockLightNode.java
@@ -8,6 +8,8 @@ import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.BlockEio;
 import crazypants.enderio.ModObject;
 
@@ -21,7 +23,7 @@ public class BlockLightNode extends BlockEio {
 
   public BlockLightNode() {
     super(ModObject.blockLightNode.unlocalisedName, TileLightNode.class, Material.air);
-    setCreativeTab(null);    
+    setCreativeTab(null);
     setBlockBounds(0, 0, 0, 0, 0, 0);
   }
 
@@ -88,12 +90,13 @@ public class BlockLightNode extends BlockEio {
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public void registerBlockIcons(IIconRegister iIconRegister) {
     blockIcon = iIconRegister.registerIcon("enderio:blockElectricLightFace");
   }
 
   @Override
-  public int quantityDropped(Random p_149745_1_) {    
+  public int quantityDropped(Random p_149745_1_) {
     return 0;
   }
 

--- a/src/main/java/crazypants/enderio/machine/painter/BlockPaintedCarpet.java
+++ b/src/main/java/crazypants/enderio/machine/painter/BlockPaintedCarpet.java
@@ -63,6 +63,7 @@ public class BlockPaintedCarpet extends BlockCarpet implements ITileEntityProvid
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public void getSubBlocks(Item item, CreativeTabs tab, List list) {
     ItemStack stack = new ItemStack(item);
     PainterUtil.setSourceBlock(stack, Blocks.stone, 0);
@@ -160,6 +161,7 @@ public class BlockPaintedCarpet extends BlockCarpet implements ITileEntityProvid
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public IIcon getIcon(IBlockAccess world, int x, int y, int z, int blockSide) {
     TileEntity te = world.getTileEntity(x, y, z);
     if(te instanceof TileEntityPaintedBlock) {

--- a/src/main/java/crazypants/enderio/machine/painter/BlockPaintedFence.java
+++ b/src/main/java/crazypants/enderio/machine/painter/BlockPaintedFence.java
@@ -65,10 +65,11 @@ public class BlockPaintedFence extends BlockFence implements ITileEntityProvider
 
   @SuppressWarnings({ "unchecked", "rawtypes" })
   @Override
+  @SideOnly(Side.CLIENT)
   public void getSubBlocks(Item item, CreativeTabs tab, List list) {
     list.add(PainterUtil.applyDefaultPaintedState(new ItemStack(item)));
   }
-  
+
   @SideOnly(Side.CLIENT)
   @Override
   public boolean addHitEffects(World world, MovingObjectPosition target,
@@ -177,6 +178,7 @@ public class BlockPaintedFence extends BlockFence implements ITileEntityProvider
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public IIcon getIcon(IBlockAccess world, int x, int y, int z, int blockSide) {
     TileEntity te = world.getTileEntity(x, y, z);
     if(te instanceof TileEntityPaintedBlock) {
@@ -287,7 +289,7 @@ public class BlockPaintedFence extends BlockFence implements ITileEntityProvider
       ItemStack paintSource = MachineRecipeInput.getInputForSlot(1, inputs);
       return new ResultStack[] { new ResultStack(createItemStackForSourceBlock(getBlockFromItem(paintSource.getItem()), paintSource.getItemDamage())) };
     }
-    
+
   }
 
 }

--- a/src/main/java/crazypants/enderio/machine/painter/BlockPaintedFenceGate.java
+++ b/src/main/java/crazypants/enderio/machine/painter/BlockPaintedFenceGate.java
@@ -56,13 +56,14 @@ public class BlockPaintedFenceGate extends BlockFenceGate implements ITileEntity
     GameRegistry.registerTileEntity(TileEntityPaintedBlock.class, ModObject.blockPaintedFenceGate.unlocalisedName + "TileEntity");
     MachineRecipeRegistry.instance.registerRecipe(ModObject.blockPainter.unlocalisedName, new PainterTemplate());
   }
-  
+
   @SuppressWarnings({ "unchecked", "rawtypes" })
   @Override
+  @SideOnly(Side.CLIENT)
   public void getSubBlocks(Item item, CreativeTabs tab, List list) {
     list.add(PainterUtil.applyDefaultPaintedState(new ItemStack(item)));
   }
-  
+
   @SideOnly(Side.CLIENT)
   @Override
   public boolean addHitEffects(World world, MovingObjectPosition target,
@@ -162,6 +163,7 @@ public class BlockPaintedFenceGate extends BlockFenceGate implements ITileEntity
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public IIcon getIcon(IBlockAccess world, int x, int y, int z, int blockSide) {
     TileEntity te = world.getTileEntity(x, y, z);
     if(te instanceof TileEntityPaintedBlock) {
@@ -241,7 +243,7 @@ public class BlockPaintedFenceGate extends BlockFenceGate implements ITileEntity
       ItemStack paintSource = MachineRecipeInput.getInputForSlot(1, inputs);
       return new ResultStack[] { new ResultStack(createItemStackForSourceBlock(Block.getBlockFromItem(paintSource.getItem()), paintSource.getItemDamage())) };
     }
-    
+
   }
 
 }

--- a/src/main/java/crazypants/enderio/machine/painter/BlockPaintedGlowstone.java
+++ b/src/main/java/crazypants/enderio/machine/painter/BlockPaintedGlowstone.java
@@ -37,7 +37,7 @@ import crazypants.util.IFacade;
 import crazypants.util.Lang;
 
 public class BlockPaintedGlowstone extends BlockEio implements ITileEntityProvider, IPaintedBlock, IFacade, IRotatableFacade {
-   
+
   public static int renderId = -1;
 
   public static BlockPaintedGlowstone create() {
@@ -70,9 +70,10 @@ public class BlockPaintedGlowstone extends BlockEio implements ITileEntityProvid
     PainterUtil.setSourceBlock(result, block, damage);
     return result;
   }
-  
+
   @SuppressWarnings({ "unchecked", "rawtypes" })
   @Override
+  @SideOnly(Side.CLIENT)
   public void getSubBlocks(Item item, CreativeTabs tab, List list) {
     list.add(PainterUtil.applyDefaultPaintedState(new ItemStack(item)));
   }
@@ -86,7 +87,7 @@ public class BlockPaintedGlowstone extends BlockEio implements ITileEntityProvid
       if(tef.getSourceBlock() != null) {
         return tef.getSourceBlock().colorMultiplier(world, x, y, z);
       }
-    }    
+    }
     return super.colorMultiplier(world, x, y, z);
   }
 
@@ -168,11 +169,12 @@ public class BlockPaintedGlowstone extends BlockEio implements ITileEntityProvid
   }
 
   @Override
-  public boolean isSideSolid(IBlockAccess world, int x, int y, int z, ForgeDirection side) {    
+  public boolean isSideSolid(IBlockAccess world, int x, int y, int z, ForgeDirection side) {
     return true;
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public IIcon getIcon(IBlockAccess world, int x, int y, int z, int blockSide) {
     TileEntity te = world.getTileEntity(x, y, z);
     if(te instanceof TileEntityPaintedBlock) {
@@ -183,7 +185,7 @@ public class BlockPaintedGlowstone extends BlockEio implements ITileEntityProvid
     }
     return Blocks.anvil.getIcon(world, x, y, z, blockSide);
   }
-   
+
   @SideOnly(Side.CLIENT)
   @Override
   public void registerBlockIcons(IIconRegister IIconRegister) {
@@ -220,14 +222,14 @@ public class BlockPaintedGlowstone extends BlockEio implements ITileEntityProvid
       drop.stackTagCompound = (NBTTagCompound) itemStack.stackTagCompound.copy();
     }
   }
-  
+
   @Override
   public boolean doNormalDrops(World world, int x, int y, int z) {
       return false;
   }
 
   @Override
-  public int getRenderType() {    
+  public int getRenderType() {
     return renderId;
   }
 
@@ -244,7 +246,7 @@ public class BlockPaintedGlowstone extends BlockEio implements ITileEntityProvid
       if(paintSource == null) {
         return new ResultStack[0];
       }
-      
+
       if (paintSource.getItem() == Item.getItemFromBlock(Blocks.glowstone)) {
         ItemStack stack = new ItemStack(Blocks.glowstone);
         stack.stackTagCompound = new NBTTagCompound();
@@ -252,10 +254,10 @@ public class BlockPaintedGlowstone extends BlockEio implements ITileEntityProvid
         stack.stackTagCompound.setBoolean(tagName, true);
         return new ResultStack[] { new ResultStack(stack) };
       }
-      
+
       return new ResultStack[] { new ResultStack(createItemStackForSourceBlock(Block.getBlockFromItem(paintSource.getItem()), paintSource.getItemDamage())) };
     }
-    
+
     @SubscribeEvent
     public void onTooltip(ItemTooltipEvent event) {
       if (event.itemStack != null && Block.getBlockFromItem(event.itemStack.getItem()) == Blocks.glowstone && event.itemStack.stackTagCompound != null) {

--- a/src/main/java/crazypants/enderio/machine/painter/BlockPaintedSlab.java
+++ b/src/main/java/crazypants/enderio/machine/painter/BlockPaintedSlab.java
@@ -68,14 +68,16 @@ public class BlockPaintedSlab extends BlockSlab implements ITileEntityProvider, 
     PainterUtil.setSourceBlock(result, source, damage);
     return result;
   }
-  
+
   @SuppressWarnings({ "unchecked", "rawtypes" })
   @Override
+  @SideOnly(Side.CLIENT)
   public void getSubBlocks(Item item, CreativeTabs tab, List list) {
     list.add(PainterUtil.applyDefaultPaintedState(new ItemStack(item)));
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public IIcon getIcon(IBlockAccess world, int x, int y, int z, int blockSide) {
     TileEntity te = world.getTileEntity(x, y, z);
     if(te instanceof TileEntityPaintedBlock) {
@@ -269,7 +271,7 @@ public class BlockPaintedSlab extends BlockSlab implements ITileEntityProvider, 
       Block blk = Block.getBlockFromItem(target.getItem());
       return blk instanceof BlockSlab;
     }
-    
+
   }
 
 }

--- a/src/main/java/crazypants/enderio/machine/painter/BlockPaintedStair.java
+++ b/src/main/java/crazypants/enderio/machine/painter/BlockPaintedStair.java
@@ -59,9 +59,10 @@ public class BlockPaintedStair extends BlockStairs implements ITileEntityProvide
     PainterUtil.setSourceBlock(result, block, damage);
     return result;
   }
-  
+
   @SuppressWarnings({ "unchecked", "rawtypes" })
   @Override
+  @SideOnly(Side.CLIENT)
   public void getSubBlocks(Item item, CreativeTabs tab, List list) {
     list.add(PainterUtil.applyDefaultPaintedState(new ItemStack(item)));
   }
@@ -151,6 +152,7 @@ public class BlockPaintedStair extends BlockStairs implements ITileEntityProvide
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public IIcon getIcon(IBlockAccess world, int x, int y, int z, int blockSide) {
     TileEntity te = world.getTileEntity(x, y, z);
     if(te instanceof TileEntityPaintedBlock) {
@@ -255,7 +257,7 @@ public class BlockPaintedStair extends BlockStairs implements ITileEntityProvide
       Block blk = Block.getBlockFromItem(target.getItem());
       return blk instanceof BlockStairs;
     }
-    
+
   }
 
 }

--- a/src/main/java/crazypants/enderio/machine/painter/BlockPaintedWall.java
+++ b/src/main/java/crazypants/enderio/machine/painter/BlockPaintedWall.java
@@ -57,9 +57,10 @@ public class BlockPaintedWall extends BlockWall implements ITileEntityProvider, 
     PainterUtil.setSourceBlock(result, id, damage);
     return result;
   }
-  
+
   @SuppressWarnings({ "unchecked", "rawtypes" })
   @Override
+  @SideOnly(Side.CLIENT)
   public void getSubBlocks(Item item, CreativeTabs tab, List list) {
     list.add(PainterUtil.applyDefaultPaintedState(new ItemStack(item)));
   }
@@ -171,6 +172,7 @@ public class BlockPaintedWall extends BlockWall implements ITileEntityProvider, 
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public IIcon getIcon(IBlockAccess world, int x, int y, int z, int blockSide) {
     TileEntity te = world.getTileEntity(x, y, z);
     if(te instanceof TileEntityPaintedBlock) {

--- a/src/main/java/crazypants/enderio/machine/painter/BlockPainter.java
+++ b/src/main/java/crazypants/enderio/machine/painter/BlockPainter.java
@@ -24,7 +24,7 @@ public class BlockPainter extends AbstractMachineBlock<TileEntityPainter> {
   }
 
   private IIcon invisibleIcon;
-  
+
   private BlockPainter() {
     super(ModObject.blockPainter, TileEntityPainter.class);
   }
@@ -41,6 +41,7 @@ public class BlockPainter extends AbstractMachineBlock<TileEntityPainter> {
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
     TileEntity te = world.getTileEntity(x, y, z);
     return new GuiPainter(player.inventory, (TileEntityPainter) te);
@@ -50,7 +51,7 @@ public class BlockPainter extends AbstractMachineBlock<TileEntityPainter> {
   protected int getGuiId() {
     return GuiHandler.GUI_ID_PAINTER;
   }
-  
+
   public IIcon getInvisibleIcon() {
     return invisibleIcon;
   }
@@ -61,7 +62,7 @@ public class BlockPainter extends AbstractMachineBlock<TileEntityPainter> {
 
   @Override
   @SideOnly(Side.CLIENT)
-  public void registerBlockIcons(IIconRegister iIconRegister) {    
+  public void registerBlockIcons(IIconRegister iIconRegister) {
     super.registerBlockIcons(iIconRegister);
     invisibleIcon = iIconRegister.registerIcon("enderio:invisblePaint");
   }

--- a/src/main/java/crazypants/enderio/machine/power/BlockCapacitorBank.java
+++ b/src/main/java/crazypants/enderio/machine/power/BlockCapacitorBank.java
@@ -138,10 +138,10 @@ public class BlockCapacitorBank extends BlockEio implements IGuiHandler, IAdvanc
 
       return true;
     }
-    
+
     return super.onBlockActivated(world, x, y, z, entityPlayer, side, par7, par8, par9);
   }
-  
+
   @Override
   protected boolean openGui(World world, int x, int y, int z, EntityPlayer entityPlayer, int side) {
     if(!world.isRemote) {
@@ -200,6 +200,7 @@ public class BlockCapacitorBank extends BlockEio implements IGuiHandler, IAdvanc
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public boolean shouldSideBeRendered(IBlockAccess par1IBlockAccess, int par2, int par3, int par4, int par5) {
     Block i1 = par1IBlockAccess.getBlock(par2, par3, par4);
     return i1 == this ? false : super.shouldSideBeRendered(par1IBlockAccess, par2, par3, par4, par5);
@@ -318,12 +319,12 @@ public class BlockCapacitorBank extends BlockEio implements IGuiHandler, IAdvanc
           if(te instanceof TileCapacitorBank) {
             if(((TileCapacitorBank)te).isMaxSize()) {
               ((EntityPlayer)player).addChatComponentMessage(new ChatComponentText("Capacitor bank is at maximum size"));
-            }            
-          }          
+            }
+          }
         }
-        
+
       }
-      
+
     }
     world.markBlockForUpdate(x, y, z);
   }
@@ -370,12 +371,12 @@ public class BlockCapacitorBank extends BlockEio implements IGuiHandler, IAdvanc
     }
     return AxisAlignedBB.getBoundingBox(min.x, min.y, min.z, max.x, max.y, max.z);
   }
-  
+
   @Override
   public boolean hasComparatorInputOverride() {
     return true;
   }
-  
+
   @Override
   public int getComparatorInputOverride(World w, int x, int y, int z, int side) {
     TileEntity te = w.getTileEntity(x, y, z);
@@ -391,7 +392,7 @@ public class BlockCapacitorBank extends BlockEio implements IGuiHandler, IAdvanc
     if (te instanceof TileCapacitorBank) {
       TileCapacitorBank cap = (TileCapacitorBank) te;
       String format = Util.TAB + Util.ALIGNRIGHT + EnumChatFormatting.WHITE;
-            
+
       tooltip.add(String.format("%s : %s%s%sRF/t ", Lang.localize("capbank.maxIO"),  format, fmt.format(cap.getMaxIO()), Util.TAB + Util.ALIGNRIGHT));
       tooltip.add(String.format("%s : %s%s%sRF/t ", Lang.localize("capbank.maxIn"),  format, fmt.format(cap.getMaxInput()), Util.TAB + Util.ALIGNRIGHT));
       tooltip.add(String.format("%s : %s%s%sRF/t ", Lang.localize("capbank.maxOut"), format, fmt.format(cap.getMaxOutput()), Util.TAB + Util.ALIGNRIGHT));

--- a/src/main/java/crazypants/enderio/machine/power/BlockItemCapacitorBank.java
+++ b/src/main/java/crazypants/enderio/machine/power/BlockItemCapacitorBank.java
@@ -8,6 +8,8 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
 import cofh.api.energy.IEnergyContainerItem;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.EnderIO;
 import crazypants.enderio.EnderIOTab;
 import crazypants.enderio.power.PowerHandlerUtil;
@@ -48,6 +50,7 @@ public class BlockItemCapacitorBank extends ItemBlock implements IEnergyContaine
 
   @Override
   @SuppressWarnings({ "rawtypes", "unchecked" })
+  @SideOnly(Side.CLIENT)
   public void getSubItems(Item par1, CreativeTabs par2CreativeTabs, List par3List) {
     ItemStack stack = createItemStackWithPower(0);
     par3List.add(stack);

--- a/src/main/java/crazypants/enderio/machine/power/CapacitorBankRenderer.java
+++ b/src/main/java/crazypants/enderio/machine/power/CapacitorBankRenderer.java
@@ -15,6 +15,8 @@ import net.minecraftforge.common.util.ForgeDirection;
 
 import org.lwjgl.opengl.GL11;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.EnderIO;
 import crazypants.enderio.power.PowerHandlerUtil;
 import crazypants.render.BoundingBox;
@@ -26,6 +28,7 @@ import crazypants.vecmath.Vector2f;
 import crazypants.vecmath.Vector4d;
 import crazypants.vecmath.Vertex;
 
+@SideOnly(Side.CLIENT)
 public class CapacitorBankRenderer extends TileEntitySpecialRenderer implements IItemRenderer {
 
   private static final BlockCoord DEFAULT_BC = new BlockCoord(0, 0, 0);

--- a/src/main/java/crazypants/enderio/machine/ranged/RangeRenerer.java
+++ b/src/main/java/crazypants/enderio/machine/ranged/RangeRenerer.java
@@ -6,45 +6,49 @@ import net.minecraft.entity.Entity;
 
 import org.lwjgl.opengl.GL11;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.render.BoundingBox;
 import crazypants.render.CubeRenderer;
 import crazypants.render.IconUtil;
 import crazypants.render.RenderUtil;
 
+@SideOnly(Side.CLIENT)
 public class RangeRenerer extends RenderEntity {
 
+  @Override
   public void doRender(Entity entity, double x, double y, double z, float p_76986_8_, float p_76986_9_) {
 
     RangeEntity se = ((RangeEntity) entity);
-    
-    GL11.glPushAttrib(GL11.GL_ENABLE_BIT);    
+
+    GL11.glPushAttrib(GL11.GL_ENABLE_BIT);
     GL11.glDisable(GL11.GL_LIGHTING);
     GL11.glDisable(GL11.GL_CULL_FACE);
     GL11.glEnable(GL11.GL_BLEND);
     GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
     GL11.glDepthMask(false);
-        
+
     float scale = 1 - ( se.lifeSpan / (float)se.totalLife);
     scale = Math.min(scale, 1);
     scale *= se.range;
-    
-    GL11.glPushMatrix();    
+
+    GL11.glPushMatrix();
     GL11.glTranslatef((float) x, (float) y, (float) z);
-    
-    GL11.glTranslatef(0.5f,0.5f,0.5f);    
+
+    GL11.glTranslatef(0.5f,0.5f,0.5f);
     GL11.glScalef(scale, scale, scale);
     GL11.glTranslatef(-0.5f,-0.5f,-0.5f);
-        
-    GL11.glColor4f(1, 1, 1, 0.4f);       
-    
+
+    GL11.glColor4f(1, 1, 1, 0.4f);
+
     RenderUtil.bindBlockTexture();
     Tessellator.instance.startDrawingQuads();
     Tessellator.instance.setBrightness(15 << 20 | 15 << 4);
     CubeRenderer.render(BoundingBox.UNIT_CUBE, IconUtil.whiteTexture);
     Tessellator.instance.draw();
-    
+
     RenderUtil.bindItemTexture();
-    
+
     GL11.glDepthMask(true);
     GL11.glPopAttrib();
     GL11.glPopMatrix();

--- a/src/main/java/crazypants/enderio/machine/reservoir/BlockReservoir.java
+++ b/src/main/java/crazypants/enderio/machine/reservoir/BlockReservoir.java
@@ -82,8 +82,8 @@ public class BlockReservoir extends BlockEio implements IResourceTooltipProvider
       } else {
         // Handle empty containers
 
-        FluidStack available = tank.getTankInfo(ForgeDirection.UNKNOWN)[0].fluid;        
-        if(available != null && available.amount > 0) {          
+        FluidStack available = tank.getTankInfo(ForgeDirection.UNKNOWN)[0].fluid;
+        if(available != null && available.amount > 0) {
           ItemStack filled = FluidContainerRegistry.fillFluidContainer(available, current);
           if(current.getItem() == Items.bucket) {
             filled = new ItemStack(Items.water_bucket);
@@ -187,6 +187,7 @@ public class BlockReservoir extends BlockEio implements IResourceTooltipProvider
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public void registerBlockIcons(IIconRegister IIconRegister) {
     blockIcon = IIconRegister.registerIcon("enderio:reservoir");
     for (MbFace face : MbFace.values()) {
@@ -201,7 +202,7 @@ public class BlockReservoir extends BlockEio implements IResourceTooltipProvider
     if (y < 0 || y >= 256) { // getTileEntity is not safe for out of bounds coords
       return false;
     }
-    
+
     TileEntity te = world.getTileEntity(x, y, z);
     if(!(te instanceof TileReservoir)) {
       return true;
@@ -214,6 +215,7 @@ public class BlockReservoir extends BlockEio implements IResourceTooltipProvider
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public IIcon getIcon(IBlockAccess world, int x, int y, int z, int blockSide) {
     // used to render the block in the world
     TileEntity te = world.getTileEntity(x, y, z);

--- a/src/main/java/crazypants/enderio/machine/reservoir/ReservoirRenderer.java
+++ b/src/main/java/crazypants/enderio/machine/reservoir/ReservoirRenderer.java
@@ -11,12 +11,15 @@ import net.minecraftforge.common.util.ForgeDirection;
 
 import org.lwjgl.opengl.GL11;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.render.BoundingBox;
 import crazypants.render.CubeRenderer;
 import crazypants.render.RenderUtil;
 import crazypants.vecmath.Vector3d;
 import crazypants.vecmath.Vector3f;
 
+@SideOnly(Side.CLIENT)
 public class ReservoirRenderer extends TileEntitySpecialRenderer {
 
   private ResourceLocation texName = null;

--- a/src/main/java/crazypants/enderio/machine/solar/BlockItemSolarPanel.java
+++ b/src/main/java/crazypants/enderio/machine/solar/BlockItemSolarPanel.java
@@ -8,6 +8,8 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemBlockWithMetadata;
 import net.minecraft.item.ItemStack;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.EnderIO;
 import crazypants.enderio.EnderIOTab;
 import crazypants.enderio.config.Config;
@@ -24,47 +26,48 @@ public class BlockItemSolarPanel extends ItemBlockWithMetadata implements IAdvan
     setHasSubtypes(true);
     setCreativeTab(EnderIOTab.tabEnderIO);
   }
-  
+
   public BlockItemSolarPanel(Block block) {
     super(block, block);
     setHasSubtypes(true);
     setCreativeTab(EnderIOTab.tabEnderIO);
   }
-  
+
   @Override
   public String getUnlocalizedName(ItemStack par1ItemStack) {
     int meta = par1ItemStack.getItemDamage();
-    String result = super.getUnlocalizedName(par1ItemStack);   
+    String result = super.getUnlocalizedName(par1ItemStack);
     if(meta == 1) {
       result += ".advanced";
     }
     return result;
   }
-  
+
   @Override
   @SuppressWarnings({ "rawtypes", "unchecked" })
+  @SideOnly(Side.CLIENT)
   public void getSubItems(Item par1, CreativeTabs par2CreativeTabs, List par3List) {
     ItemStack stack = new ItemStack(this, 1,0);
     par3List.add(stack);
     stack = new ItemStack(this, 1,1);
     par3List.add(stack);
   }
-  
+
   @SuppressWarnings("rawtypes")
   @Override
-  public void addCommonEntries(ItemStack itemstack, EntityPlayer entityplayer, List list, boolean flag) {       
+  public void addCommonEntries(ItemStack itemstack, EntityPlayer entityplayer, List list, boolean flag) {
     TooltipAddera.addCommonTooltipFromResources(list, itemstack);
   }
 
   @SuppressWarnings("rawtypes")
   @Override
-  public void addBasicEntries(ItemStack itemstack, EntityPlayer entityplayer, List list, boolean flag) {       
+  public void addBasicEntries(ItemStack itemstack, EntityPlayer entityplayer, List list, boolean flag) {
   }
 
   @SuppressWarnings({ "unchecked", "rawtypes" })
   @Override
   public void addDetailedEntries(ItemStack itemstack, EntityPlayer entityplayer, List list, boolean flag) {
-    TooltipAddera.addDetailedTooltipFromResources(list, itemstack); 
+    TooltipAddera.addDetailedTooltipFromResources(list, itemstack);
     int prod = Config.maxPhotovoltaicOutputRF;
     if(itemstack.getItemDamage() == 1) {
       prod = Config.maxPhotovoltaicAdvancedOutputRF;

--- a/src/main/java/crazypants/enderio/machine/solar/BlockSolarPanel.java
+++ b/src/main/java/crazypants/enderio/machine/solar/BlockSolarPanel.java
@@ -14,18 +14,15 @@ import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
-import cofh.api.energy.EnergyStorage;
 import cpw.mods.fml.common.registry.GameRegistry;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.BlockEio;
 import crazypants.enderio.ModObject;
-import crazypants.enderio.api.tool.ITool;
 import crazypants.enderio.config.Config;
 import crazypants.enderio.gui.IResourceTooltipProvider;
-import crazypants.enderio.tool.ToolUtil;
 import crazypants.enderio.waila.IWailaInfoProvider;
-import crazypants.enderio.waila.WailaCompat;
 import crazypants.util.Lang;
-import crazypants.util.Util;
 
 public class BlockSolarPanel extends BlockEio implements IResourceTooltipProvider, IWailaInfoProvider {
 
@@ -78,6 +75,7 @@ public class BlockSolarPanel extends BlockEio implements IResourceTooltipProvide
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public IIcon getIcon(int side, int meta) {
     if(side == ForgeDirection.UP.ordinal()) {
       return meta == 0 ? blockIcon : advancedIcon;
@@ -103,6 +101,7 @@ public class BlockSolarPanel extends BlockEio implements IResourceTooltipProvide
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public void registerBlockIcons(IIconRegister register) {
     blockIcon = register.registerIcon("enderio:solarPanelTop");
     advancedIcon = register.registerIcon("enderio:solarPanelAdvancedTop");

--- a/src/main/java/crazypants/enderio/machine/spawner/ItemBrokenSpawner.java
+++ b/src/main/java/crazypants/enderio/machine/spawner/ItemBrokenSpawner.java
@@ -18,9 +18,9 @@ import crazypants.enderio.ModObject;
 import crazypants.enderio.gui.TooltipAddera;
 
 public class ItemBrokenSpawner extends Item {
-  
+
   private static final String[] CREATIVE_TYPES = new String[] {
-    "Skeleton", 
+    "Skeleton",
     "Zombie",
     "Spider",
     "CaveSpider",
@@ -28,14 +28,14 @@ public class ItemBrokenSpawner extends Item {
       "Enderman",
       "Chicken"
   };
-  
+
   public static String getMobTypeFromStack(ItemStack stack) {
     if(stack == null || stack.stackTagCompound == null || !stack.stackTagCompound.hasKey("mobType")) {
       return null;
     }
     return stack.stackTagCompound.getString("mobType");
   }
-  
+
   public static ItemStack createStackForMobType(String mobType) {
     if(mobType == null) {
       return null;
@@ -45,14 +45,14 @@ public class ItemBrokenSpawner extends Item {
     res.stackTagCompound.setString("mobType", mobType);
     return res;
   }
-  
-  
+
+
   public static ItemBrokenSpawner create() {
     ItemBrokenSpawner result = new ItemBrokenSpawner();
     result.init();
     return result;
   }
-  
+
 
   protected ItemBrokenSpawner() {
     setCreativeTab(EnderIOTab.tabEnderIO);
@@ -63,7 +63,7 @@ public class ItemBrokenSpawner extends Item {
   }
 
   @Override
-  public boolean isDamageable() {  
+  public boolean isDamageable() {
     return false;
   }
 
@@ -72,16 +72,18 @@ public class ItemBrokenSpawner extends Item {
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public void registerIcons(IIconRegister iIconRegister) {
-    itemIcon = iIconRegister.registerIcon("enderio:itemBrokenSpawner");    
+    itemIcon = iIconRegister.registerIcon("enderio:itemBrokenSpawner");
   }
 
   @Override
   @SuppressWarnings({ "rawtypes", "unchecked" })
+  @SideOnly(Side.CLIENT)
   public void getSubItems(Item par1, CreativeTabs par2CreativeTabs, List par3List) {
     for(String mobType : CREATIVE_TYPES) {
       par3List.add(createStackForMobType(mobType));
-    }    
+    }
   }
 
 

--- a/src/main/java/crazypants/enderio/machine/spawnguard/SpawnGuardRenderer.java
+++ b/src/main/java/crazypants/enderio/machine/spawnguard/SpawnGuardRenderer.java
@@ -1,15 +1,18 @@
 package crazypants.enderio.machine.spawnguard;
 
 import net.minecraft.item.ItemStack;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.EnderIO;
 import crazypants.enderio.item.skull.BlockEndermanSkull;
 import crazypants.enderio.machine.attractor.ObeliskRenderer;
 
+@SideOnly(Side.CLIENT)
 public class SpawnGuardRenderer extends ObeliskRenderer<TileSpawnGuard> {
 
   private ItemStack offStack = new ItemStack(EnderIO.blockEndermanSkull, 1, BlockEndermanSkull.SkullType.TORMENTED.ordinal());
   private ItemStack onStack = new ItemStack(EnderIO.blockEndermanSkull, 1, BlockEndermanSkull.SkullType.REANIMATED_TORMENTED.ordinal());
-  
+
   public SpawnGuardRenderer() {
     super(null);
   }
@@ -19,13 +22,13 @@ public class SpawnGuardRenderer extends ObeliskRenderer<TileSpawnGuard> {
     if(te == null) {
       return offStack;
     }
-    TileSpawnGuard sg = (TileSpawnGuard)te;
+    TileSpawnGuard sg = te;
     if(sg.isActive()) {
       return onStack;
     }
     return offStack;
   }
 
-  
-  
+
+
 }

--- a/src/main/java/crazypants/enderio/machine/tank/BlockItemTank.java
+++ b/src/main/java/crazypants/enderio/machine/tank/BlockItemTank.java
@@ -8,6 +8,8 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemBlockWithMetadata;
 import net.minecraft.item.ItemStack;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.EnderIO;
 import crazypants.enderio.EnderIOTab;
 import crazypants.enderio.gui.IAdvancedTooltipProvider;
@@ -19,7 +21,7 @@ public class BlockItemTank extends ItemBlockWithMetadata implements IAdvancedToo
     setHasSubtypes(true);
     setCreativeTab(EnderIOTab.tabEnderIO);
   }
-  
+
   public BlockItemTank(Block block) {
     super(block, block);
     setHasSubtypes(true);
@@ -29,15 +31,16 @@ public class BlockItemTank extends ItemBlockWithMetadata implements IAdvancedToo
   @Override
   public String getUnlocalizedName(ItemStack par1ItemStack) {
     int meta = par1ItemStack.getItemDamage();
-    String result = super.getUnlocalizedName(par1ItemStack);   
+    String result = super.getUnlocalizedName(par1ItemStack);
     if(meta == 1) {
       result += ".advanced";
     }
     return result;
   }
-  
+
   @Override
   @SuppressWarnings({ "rawtypes", "unchecked" })
+  @SideOnly(Side.CLIENT)
   public void getSubItems(Item par1, CreativeTabs par2CreativeTabs, List par3List) {
     ItemStack stack = new ItemStack(this, 1,0);
     par3List.add(stack);
@@ -47,19 +50,19 @@ public class BlockItemTank extends ItemBlockWithMetadata implements IAdvancedToo
 
   @Override
   public void addCommonEntries(ItemStack itemstack, EntityPlayer entityplayer, List list, boolean flag) {
-    EnderIO.blockTank.addCommonEntries(itemstack, entityplayer, list, flag);    
+    EnderIO.blockTank.addCommonEntries(itemstack, entityplayer, list, flag);
   }
 
   @Override
   public void addBasicEntries(ItemStack itemstack, EntityPlayer entityplayer, List list, boolean flag) {
-    EnderIO.blockTank.addBasicEntries(itemstack, entityplayer, list, flag);    
+    EnderIO.blockTank.addBasicEntries(itemstack, entityplayer, list, flag);
   }
 
   @Override
   public void addDetailedEntries(ItemStack itemstack, EntityPlayer entityplayer, List list, boolean flag) {
-    EnderIO.blockTank.addDetailedEntries(itemstack, entityplayer, list, flag);    
+    EnderIO.blockTank.addDetailedEntries(itemstack, entityplayer, list, flag);
   }
-  
-  
+
+
 
 }

--- a/src/main/java/crazypants/enderio/machine/tank/BlockTank.java
+++ b/src/main/java/crazypants/enderio/machine/tank/BlockTank.java
@@ -49,7 +49,7 @@ public class BlockTank extends AbstractMachineBlock<TileTank> implements IAdvanc
     setStepSound(Block.soundTypeGlass);
     setLightOpacity(0);
   }
-  
+
   @Override
   protected void init() {
     GameRegistry.registerBlock(this, BlockItemTank.class, modObject.unlocalisedName);
@@ -64,11 +64,12 @@ public class BlockTank extends AbstractMachineBlock<TileTank> implements IAdvanc
 
   @SuppressWarnings({ "unchecked", "rawtypes" })
   @Override
+  @SideOnly(Side.CLIENT)
   public void getSubBlocks(Item item, CreativeTabs p_149666_2_, List list) {
     list.add(new ItemStack(this, 1, 0));
     list.add(new ItemStack(this, 1, 1));
   }
-  
+
   @Override
   public TileEntity createTileEntity(World world, int metadata) {
     return new TileTank(metadata);
@@ -110,9 +111,9 @@ public class BlockTank extends AbstractMachineBlock<TileTank> implements IAdvanc
       if(filled == null) { //this shouldn't be necessary but it appears to be a bug as the above method doesnt work
         FluidContainerData[] datas = FluidContainerRegistry.getRegisteredFluidContainerData();
         for (FluidContainerData data : datas) {
-          if(data != null && data.fluid != null && data.fluid.getFluid() != null && 
-              data.fluid.getFluid().getName() != null && data.emptyContainer != null &&               
-              data.fluid.getFluid().getName().equals(available.getFluid().getName()) && 
+          if(data != null && data.fluid != null && data.fluid.getFluid() != null &&
+              data.fluid.getFluid().getName() != null && data.emptyContainer != null &&
+              data.fluid.getFluid().getName().equals(available.getFluid().getName()) &&
               data.emptyContainer.isItemEqual(item)) {
             res = data.filledContainer.copy();
             filled = FluidContainerRegistry.getFluidForFilledItem(res);
@@ -174,6 +175,7 @@ public class BlockTank extends AbstractMachineBlock<TileTank> implements IAdvanc
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public IIcon getIcon(IBlockAccess world, int x, int y, int z, int blockSide) {
 
     // used to render the block in the world
@@ -193,6 +195,7 @@ public class BlockTank extends AbstractMachineBlock<TileTank> implements IAdvanc
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public IIcon getIcon(int blockSide, int blockMeta) {
     int offset = MathHelper.clamp_int(blockMeta, 0, 1) == 0 ? 0 : 6;
     return iconBuffer[0][blockSide + offset];
@@ -206,10 +209,12 @@ public class BlockTank extends AbstractMachineBlock<TileTank> implements IAdvanc
     return "enderio:blockTank";
   }
 
+  @Override
   protected String getSideIconKey(boolean active) {
     return getMachineFrontIconKey(active);
   }
 
+  @Override
   protected String getBackIconKey(boolean active) {
     return getMachineFrontIconKey(active);
   }
@@ -237,12 +242,12 @@ public class BlockTank extends AbstractMachineBlock<TileTank> implements IAdvanc
       return super.getExplosionResistance(par1Entity);
     }
   }
-  
+
   @Override
   public boolean hasComparatorInputOverride() {
     return true;
   }
-  
+
   @Override
   public int getComparatorInputOverride(World w, int x, int y, int z, int side) {
     TileEntity te = w.getTileEntity(x, y, z);
@@ -287,7 +292,7 @@ public class BlockTank extends AbstractMachineBlock<TileTank> implements IAdvanc
       FluidStack stored = tank.tank.getFluid();
       String fluid = stored == null ? Lang.localize("tooltip.none") : stored.getFluid().getLocalizedName(stored);
       int amount = stored == null ? 0 : stored.amount;
-      
+
       tooltip.add(String.format("%s%s : %s (%d %s)", EnumChatFormatting.WHITE, Lang.localize("tooltip.fluidStored"), fluid, amount, Lang.localize("fluid.millibucket.abr")));
     }
   }

--- a/src/main/java/crazypants/enderio/machine/tank/TankFluidRenderer.java
+++ b/src/main/java/crazypants/enderio/machine/tank/TankFluidRenderer.java
@@ -7,22 +7,25 @@ import net.minecraft.util.IIcon;
 
 import org.lwjgl.opengl.GL11;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.render.BoundingBox;
 import crazypants.render.CubeRenderer;
 import crazypants.render.RenderUtil;
 
+@SideOnly(Side.CLIENT)
 public class TankFluidRenderer extends TileEntitySpecialRenderer {
 
   @Override
   public void renderTileEntityAt(TileEntity te, double x, double y, double z, float partialTick) {
-    
+
     TileTank tank = (TileTank)te;
     if(tank.tank.getFluidAmount() <= 0) {
       return;
-    }    
-    renderTankFluid(tank.tank, (float)x, (float)y, (float)z);    
+    }
+    renderTankFluid(tank.tank, (float)x, (float)y, (float)z);
   }
-  
+
   public static void renderTankFluid(FluidTankEio tank, float x, float y, float z) {
     if(tank == null || tank.getFluid() == null) {
       return;
@@ -41,15 +44,15 @@ public class TankFluidRenderer extends TileEntitySpecialRenderer {
       GL11.glDisable(GL11.GL_LIGHTING);
       GL11.glEnable(GL11.GL_BLEND);
       GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
-      
+
       RenderUtil.bindBlockTexture();
-      
+
       Tessellator.instance.startDrawingQuads();
       Tessellator.instance.addTranslation(x, y, z);
       CubeRenderer.render(bb, icon);
       Tessellator.instance.addTranslation(-x, -y, -z);
       Tessellator.instance.draw();
-      
+
       GL11.glPopAttrib();
     }
   }

--- a/src/main/java/crazypants/enderio/machine/transceiver/BlockTransceiver.java
+++ b/src/main/java/crazypants/enderio/machine/transceiver/BlockTransceiver.java
@@ -11,6 +11,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.common.MinecraftForge;
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.GuiHandler;
 import crazypants.enderio.ModObject;
 import crazypants.enderio.config.Config;
@@ -24,10 +25,10 @@ import crazypants.util.Util;
 public class BlockTransceiver extends AbstractMachineBlock<TileTransceiver> {
 
   public static BlockTransceiver create() {
-    
+
     PacketHandler.INSTANCE.registerMessage(PacketSendRecieveChannel.class, PacketSendRecieveChannel.class, PacketHandler.nextID(), Side.SERVER);
     PacketHandler.INSTANCE.registerMessage(PacketAddRemoveChannel.class, PacketAddRemoveChannel.class, PacketHandler.nextID(), Side.SERVER);
-    PacketHandler.INSTANCE.registerMessage(PacketAddRemoveChannel.class, PacketAddRemoveChannel.class, PacketHandler.nextID(), Side.CLIENT);    
+    PacketHandler.INSTANCE.registerMessage(PacketAddRemoveChannel.class, PacketAddRemoveChannel.class, PacketHandler.nextID(), Side.CLIENT);
     PacketHandler.INSTANCE.registerMessage(PacketChannelList.class, PacketChannelList.class, PacketHandler.nextID(), Side.CLIENT);
     PacketHandler.INSTANCE.registerMessage(PacketSendRecieveChannelList.class, PacketSendRecieveChannelList.class, PacketHandler.nextID(), Side.CLIENT);
     PacketHandler.INSTANCE.registerMessage(PacketItemFilter.class, PacketItemFilter.class, PacketHandler.nextID(), Side.SERVER);
@@ -35,7 +36,7 @@ public class BlockTransceiver extends AbstractMachineBlock<TileTransceiver> {
     ConnectionHandler ch = new ConnectionHandler();
     FMLCommonHandler.instance().bus().register(ch);
     MinecraftForge.EVENT_BUS.register(ch);
-    
+
     BlockTransceiver res = new BlockTransceiver();
     res.init();
     return res;
@@ -49,13 +50,13 @@ public class BlockTransceiver extends AbstractMachineBlock<TileTransceiver> {
   }
 
   @Override
-  public boolean removedByPlayer(World world, EntityPlayer player, int x, int y, int z, boolean doHarvest) {   
+  public boolean removedByPlayer(World world, EntityPlayer player, int x, int y, int z, boolean doHarvest) {
     if(!world.isRemote) {
       TileEntity te = world.getTileEntity(x, y, z);
       if(te instanceof TileTransceiver) {
         ((TileTransceiver)te).getRailController().dropNonSpawnedCarts();
       }
-    }        
+    }
     return super.removedByPlayer(world, player, x, y, z, doHarvest);
   }
 
@@ -79,8 +80,9 @@ public class BlockTransceiver extends AbstractMachineBlock<TileTransceiver> {
     return GuiHandler.GUI_ID_TRANSCEIVER;
   }
 
-  
+
   @Override
+  @SideOnly(Side.CLIENT)
   protected void registerOverlayIcons(IIconRegister iIconRegister) {
     overlayIconPull = iIconRegister.registerIcon("enderio:transcieverOverlayPull");
     overlayIconPush = iIconRegister.registerIcon("enderio:transcieverOverlayPush");
@@ -89,7 +91,7 @@ public class BlockTransceiver extends AbstractMachineBlock<TileTransceiver> {
     overlayIconNone = iIconRegister.registerIcon("enderio:machineOverlayNone");
     selectedFaceIcon= iIconRegister.registerIcon("enderio:machineOverlaySelectedFace");
   }
-  
+
   @Override
   protected String getMachineFrontIconKey(boolean active) {
     if(active) {
@@ -97,7 +99,7 @@ public class BlockTransceiver extends AbstractMachineBlock<TileTransceiver> {
     }
     return "enderio:alloySmelterFront";
   }
-  
+
   @Override
   public int getRenderType() {
     return -1;
@@ -114,9 +116,10 @@ public class BlockTransceiver extends AbstractMachineBlock<TileTransceiver> {
   }
 
   @Override
-  public void randomDisplayTick(World world, int x, int y, int z, Random rand) {    
+  @SideOnly(Side.CLIENT)
+  public void randomDisplayTick(World world, int x, int y, int z, Random rand) {
   }
-  
+
   @Override
   public void getWailaInfo(List<String> tooltip, EntityPlayer player, World world, int x, int y, int z) {
     TileEntity te = world.getTileEntity(x, y, z);
@@ -146,11 +149,11 @@ public class BlockTransceiver extends AbstractMachineBlock<TileTransceiver> {
       }
     }
   }
-  
+
   private boolean isEmpty(String str) {
     return "[]".equals(str);
   }
-  
+
   private String buildString(List<Channel> channels) {
     StringBuilder sb = new StringBuilder();
     for (Channel c : channels) {
@@ -161,5 +164,5 @@ public class BlockTransceiver extends AbstractMachineBlock<TileTransceiver> {
     }
     return sb.toString();
   }
-  
+
 }

--- a/src/main/java/crazypants/enderio/machine/transceiver/render/TransceiverRenderer.java
+++ b/src/main/java/crazypants/enderio/machine/transceiver/render/TransceiverRenderer.java
@@ -1,13 +1,8 @@
 package crazypants.enderio.machine.transceiver.render;
 
-import java.util.List;
-
-import net.minecraft.block.Block;
 import net.minecraft.client.renderer.OpenGlHelper;
-import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
-import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.IIcon;
@@ -18,20 +13,18 @@ import net.minecraftforge.common.util.ForgeDirection;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL12;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.EnderIO;
 import crazypants.enderio.config.Config;
-import crazypants.enderio.machine.AbstractMachineBlock;
 import crazypants.enderio.machine.IoMode;
 import crazypants.enderio.machine.transceiver.TileTransceiver;
 import crazypants.render.BoundingBox;
 import crazypants.render.CubeRenderer;
-import crazypants.render.CustomCubeRenderer;
 import crazypants.render.CustomRenderBlocks;
-import crazypants.render.IRenderFace;
-import crazypants.render.IconUtil;
 import crazypants.render.RenderUtil;
-import crazypants.vecmath.Vertex;
 
+@SideOnly(Side.CLIENT)
 public class TransceiverRenderer extends TileEntitySpecialRenderer implements IItemRenderer {
 
   private IModel model;
@@ -64,7 +57,7 @@ public class TransceiverRenderer extends TileEntitySpecialRenderer implements II
     int l1 = l % 65536;
     int l2 = l / 65536;
     Tessellator.instance.setColorOpaque_F(f, f, f);
-    OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, (float) l1, (float) l2);
+    OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, l1, l2);
 
     model.render(trans, x, y, z);
     if(trans.isActive()) {
@@ -78,26 +71,26 @@ public class TransceiverRenderer extends TileEntitySpecialRenderer implements II
     GL11.glDisable(GL11.GL_LIGHTING);
     Tessellator.instance.startDrawingQuads();
     Tessellator.instance.setColorOpaque_F(f, f, f);
-    
+
 
     RenderUtil.bindBlockTexture();
     CustomRenderBlocks rb = new CustomRenderBlocks(te.getWorldObj());
     double scale = 0.88;
     BoundingBox pushPullBounds = BoundingBox.UNIT_CUBE.scale(scale, scale, scale);
     BoundingBox disabledBounds = BoundingBox.UNIT_CUBE.scale(1.01, 1.01, 1.01);
-    
+
     for (ForgeDirection dir : ForgeDirection.VALID_DIRECTIONS) {
       IoMode mode = trans.getIoMode(dir);
       if(mode != null) {
         if(mode == IoMode.DISABLED) {
-          rb.setRenderBounds(disabledBounds.minX, disabledBounds.minY, disabledBounds.minZ, 
+          rb.setRenderBounds(disabledBounds.minX, disabledBounds.minY, disabledBounds.minZ,
               disabledBounds.maxX, disabledBounds.maxY, disabledBounds.maxZ);
         } else {
-          rb.setRenderBounds(pushPullBounds.minX, pushPullBounds.minY, pushPullBounds.minZ, 
-              pushPullBounds.maxX, pushPullBounds.maxY, pushPullBounds.maxZ);      
+          rb.setRenderBounds(pushPullBounds.minX, pushPullBounds.minY, pushPullBounds.minZ,
+              pushPullBounds.maxX, pushPullBounds.maxY, pushPullBounds.maxZ);
         }
         IIcon icon = EnderIO.blockTransceiver.getOverlayIconForMode(mode);
-        if(icon != null) {          
+        if(icon != null) {
           rb.doDefaultRenderFace(dir, EnderIO.blockTransceiver, 0, 0, 0, icon);
         }
       }

--- a/src/main/java/crazypants/enderio/machine/vat/BlockVat.java
+++ b/src/main/java/crazypants/enderio/machine/vat/BlockVat.java
@@ -1,5 +1,7 @@
 package crazypants.enderio.machine.vat;
 
+import static crazypants.util.FluidUtil.isValidFluid;
+
 import java.util.Random;
 
 import net.minecraft.client.renderer.texture.IIconRegister;
@@ -25,8 +27,6 @@ import crazypants.util.FluidUtil;
 import crazypants.util.Util;
 import crazypants.vecmath.Vector3d;
 
-import static crazypants.util.FluidUtil.isValidFluid;
-
 public class BlockVat extends AbstractMachineBlock<TileVat> {
 
   public static int renderId;
@@ -50,6 +50,7 @@ public class BlockVat extends AbstractMachineBlock<TileVat> {
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public void registerBlockIcons(IIconRegister iIconRegister) {
     blockIcon = iIconRegister.registerIcon("enderio:vatFront");
     blockIconSingle = iIconRegister.registerIcon("enderio:vatFrontSingle");
@@ -71,6 +72,7 @@ public class BlockVat extends AbstractMachineBlock<TileVat> {
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public IIcon getIcon(IBlockAccess world, int x, int y, int z, int blockSide) {
     // used to render the block in the world
     TileEntity te = world.getTileEntity(x, y, z);
@@ -100,6 +102,7 @@ public class BlockVat extends AbstractMachineBlock<TileVat> {
 
 
   @Override
+  @SideOnly(Side.CLIENT)
   public IIcon getIcon(int blockSide, int blockMeta) {
     if(blockSide == ForgeDirection.UP.ordinal() || blockSide == ForgeDirection.DOWN.ordinal()) {
       return topIcon;
@@ -232,6 +235,7 @@ public class BlockVat extends AbstractMachineBlock<TileVat> {
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public void randomDisplayTick(World world, int x, int y, int z, Random rand) {
     // If active, randomly throw some smoke around
     if(isActive(world, x, y, z)) {

--- a/src/main/java/crazypants/enderio/machine/weather/BlockWeatherObelisk.java
+++ b/src/main/java/crazypants/enderio/machine/weather/BlockWeatherObelisk.java
@@ -5,6 +5,7 @@ import java.util.Random;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.world.World;
 import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.GuiHandler;
 import crazypants.enderio.ModObject;
 import crazypants.enderio.machine.AbstractMachineBlock;
@@ -22,7 +23,7 @@ public class BlockWeatherObelisk extends AbstractMachineBlock<TileWeatherObelisk
     PacketHandler.INSTANCE.registerMessage(PacketFinishWeather.Handler.class, PacketFinishWeather.class, PacketHandler.nextID(), Side.CLIENT);
     return ret;
   }
-  
+
   private BlockWeatherObelisk() {
     super(ModObject.blockWeatherObelisk, TileWeatherObelisk.class);
     setObeliskBounds();
@@ -37,7 +38,7 @@ public class BlockWeatherObelisk extends AbstractMachineBlock<TileWeatherObelisk
   public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
     return new GuiWeatherObelisk(player.inventory, (TileWeatherObelisk) world.getTileEntity(x, y, z));
   }
-  
+
   @Override
   public boolean renderAsNormalBlock() {
     return false;
@@ -47,12 +48,12 @@ public class BlockWeatherObelisk extends AbstractMachineBlock<TileWeatherObelisk
   public boolean isOpaqueCube() {
     return false;
   }
-  
+
   @Override
   public int getLightOpacity() {
     return 0;
   }
-  
+
   @Override
   public int getRenderType() {
     return renderId;
@@ -80,8 +81,9 @@ public class BlockWeatherObelisk extends AbstractMachineBlock<TileWeatherObelisk
   protected String getBackIconKey(boolean active) {
     return getMachineFrontIconKey(active);
   }
-  
+
   @Override
+  @SideOnly(Side.CLIENT)
   public void randomDisplayTick(World world, int x, int y, int z, Random rand) {
     ; // no active smoke
   }

--- a/src/main/java/crazypants/enderio/machine/wireless/BlockWirelessCharger.java
+++ b/src/main/java/crazypants/enderio/machine/wireless/BlockWirelessCharger.java
@@ -38,6 +38,7 @@ public class BlockWirelessCharger extends BlockEio implements IResourceTooltipPr
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public void registerBlockIcons(IIconRegister iIconRegister) {
     centerOn = iIconRegister.registerIcon("enderio:blockWirelessChargerOn");
     centerOff = iIconRegister.registerIcon("enderio:blockWirelessChargerOff");

--- a/src/main/java/crazypants/enderio/machine/xp/BlockExperienceObelisk.java
+++ b/src/main/java/crazypants/enderio/machine/xp/BlockExperienceObelisk.java
@@ -4,7 +4,6 @@ import java.util.Random;
 
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
-import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
@@ -25,15 +24,15 @@ public class BlockExperienceObelisk extends AbstractMachineBlock<TileExperienceO
   }
 
   public static int renderId;
-  
+
   private BlockExperienceObelisk() {
     super(ModObject.blockExperienceObelisk, TileExperienceOblisk.class);
     setObeliskBounds();
   }
-    
+
   @Override
   @SideOnly(Side.CLIENT)
-  public IIcon getIcon(IBlockAccess world, int x, int y, int z, int blockSide) {    
+  public IIcon getIcon(IBlockAccess world, int x, int y, int z, int blockSide) {
     return getIcon(blockSide, 0);
   }
 
@@ -55,14 +54,14 @@ public class BlockExperienceObelisk extends AbstractMachineBlock<TileExperienceO
   public boolean isOpaqueCube() {
     return false;
   }
-  
+
   @Override
   public int getLightOpacity() {
     return 0;
   }
-  
+
   @Override
-  public int getRenderType() {    
+  public int getRenderType() {
     return renderId;
   }
 
@@ -71,23 +70,23 @@ public class BlockExperienceObelisk extends AbstractMachineBlock<TileExperienceO
 //    ItemXpTransfer.onActivated(player, world, x, y - 1, z, side);
 //    return true;
 //  }
-//  
+//
 //  @Override
 //  public void onBlockClicked(World world, int x, int y, int z, EntityPlayer player) {
 //    super.onBlockClicked(world, x, y, z, player);
-//        
+//
 //    // copypasta from ItemXpTransfer.transferFromPlayerToBlock
-//    
+//
 //    if(world.isRemote || player.experienceTotal <= 0) {
 //      return;
 //    }
-//    
+//
 //    y--;
 //    TileEntity te = world.getTileEntity(x, y, z);
 //    if(!(te instanceof IFluidHandler)) {
 //      return;
 //    }
-//    
+//
 //    IFluidHandler fh = (IFluidHandler) te;
 //    ForgeDirection dir = ForgeDirection.UP; // no side passed :(
 //    if(!fh.canFill(dir, EnderIO.fluidXpJuice)) {
@@ -95,14 +94,14 @@ public class BlockExperienceObelisk extends AbstractMachineBlock<TileExperienceO
 //    }
 //
 //    int canTake = player.experienceTotal - XpUtil.getExperienceForLevel(player.experienceLevel - 1);
-//    
+//
 //    int fluidVolume = XpUtil.experianceToLiquid(canTake);
 //    FluidStack fs = new FluidStack(EnderIO.fluidXpJuice, fluidVolume);
 //    int takenVolume = fh.fill(dir, fs, true);
 //    if(takenVolume <= 0) {
 //      return;
 //    }
-//    
+//
 //    int xpToTake = XpUtil.liquidToExperiance(takenVolume);
 //    XpUtil.addPlayerXP(player, -xpToTake);
 //    ItemXpTransfer.sendXPUpdate(player, world, x, y, z, false);
@@ -112,10 +111,10 @@ public class BlockExperienceObelisk extends AbstractMachineBlock<TileExperienceO
   public String getUnlocalizedNameForTooltip(ItemStack itemStack) {
     return getUnlocalizedName();
   }
-  
+
   //  @Override
   //  public void registerBlockIcons(IIconRegister iIconRegister) {
-  //    
+  //
   //    blockIcon = iIconRegister.registerIcon("enderio:blockAttractorSide");
   //  }
 
@@ -141,7 +140,8 @@ public class BlockExperienceObelisk extends AbstractMachineBlock<TileExperienceO
   }
 
   @Override
-  public void randomDisplayTick(World world, int x, int y, int z, Random rand) {    
-  }  
-  
+  @SideOnly(Side.CLIENT)
+  public void randomDisplayTick(World world, int x, int y, int z, Random rand) {
+  }
+
 }

--- a/src/main/java/crazypants/enderio/material/BlockFusedQuartz.java
+++ b/src/main/java/crazypants/enderio/material/BlockFusedQuartz.java
@@ -7,11 +7,9 @@ import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.Entity;
-import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
-import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.IIcon;
 import net.minecraft.util.MathHelper;
 import net.minecraft.world.IBlockAccess;
@@ -158,6 +156,7 @@ public class BlockFusedQuartz extends BlockEio {
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public void getSubBlocks(Item par1, CreativeTabs par2CreativeTabs, List par3List) {
     for (int j = 0; j < Type.values().length; ++j) {
       par3List.add(new ItemStack(par1, 1, j));
@@ -165,6 +164,7 @@ public class BlockFusedQuartz extends BlockEio {
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public boolean shouldSideBeRendered(IBlockAccess world, int x, int y, int z, int side) {
     Block block = world.getBlock(x, y, z);
     int meta = world.getBlockMetadata(x, y, z);
@@ -195,6 +195,7 @@ public class BlockFusedQuartz extends BlockEio {
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public void registerBlockIcons(IIconRegister iIconRegister) {
     //This little oddity is so the standard rendering used for items and breaking effects
     //uses the item texture, while the custom renderer uses 'realBlockIcon' to render the 'non-frame' part of the block.

--- a/src/main/java/crazypants/enderio/material/ItemAlloy.java
+++ b/src/main/java/crazypants/enderio/material/ItemAlloy.java
@@ -9,6 +9,8 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.IIcon;
 import net.minecraft.util.MathHelper;
 import cpw.mods.fml.common.registry.GameRegistry;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.EnderIOTab;
 import crazypants.enderio.ModObject;
 
@@ -43,12 +45,14 @@ public class ItemAlloy extends Item {
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public IIcon getIconFromDamage(int damage) {
     damage = MathHelper.clamp_int(damage, 0, numItems - 1);
     return icons[damage];
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public void registerIcons(IIconRegister IIconRegister) {
     int numAlloys = Alloy.values().length;
     for (int i = 0; i < numAlloys; i++) {
@@ -73,6 +77,7 @@ public class ItemAlloy extends Item {
 
   @Override
   @SuppressWarnings({ "rawtypes", "unchecked" })
+  @SideOnly(Side.CLIENT)
   public void getSubItems(Item par1, CreativeTabs par2CreativeTabs, List par3List) {
     for (int j = 0; j < numItems; ++j) {
       par3List.add(new ItemStack(par1, 1, j));

--- a/src/main/java/crazypants/enderio/material/ItemCapacitor.java
+++ b/src/main/java/crazypants/enderio/material/ItemCapacitor.java
@@ -48,12 +48,14 @@ public class ItemCapacitor extends Item implements ICapacitorItem {
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public IIcon getIconFromDamage(int damage) {
     damage = MathHelper.clamp_int(damage, 0, Capacitors.values().length - 1);
     return icons[damage];
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public void registerIcons(IIconRegister IIconRegister) {
     for (int i = 0; i < Capacitors.values().length; i++) {
       icons[i] = IIconRegister.registerIcon(Capacitors.values()[i].iconKey);
@@ -68,6 +70,7 @@ public class ItemCapacitor extends Item implements ICapacitorItem {
 
   @Override
   @SuppressWarnings({ "rawtypes", "unchecked" })
+  @SideOnly(Side.CLIENT)
   public void getSubItems(Item par1, CreativeTabs par2CreativeTabs, List par3List) {
     for (int j = 0; j < Capacitors.values().length; ++j) {
       par3List.add(new ItemStack(par1, 1, j));
@@ -84,7 +87,7 @@ public class ItemCapacitor extends Item implements ICapacitorItem {
   @SideOnly(Side.CLIENT)
   public void addInformation(ItemStack par1ItemStack, EntityPlayer par2EntityPlayer, List par3List, boolean par4) {
     if(par1ItemStack != null && par1ItemStack.getItemDamage() > 0) {
-      par3List.add(Lang.localize("machine.tooltip.upgrade"));      
+      par3List.add(Lang.localize("machine.tooltip.upgrade"));
       if(TooltipAddera.instance.showAdvancedTooltips()) {
         TooltipAddera.instance.addDetailedTooltipFromResources(par3List, "enderio.machine.tooltip.upgrade");
       } else {

--- a/src/main/java/crazypants/enderio/material/ItemFrankenSkull.java
+++ b/src/main/java/crazypants/enderio/material/ItemFrankenSkull.java
@@ -16,7 +16,7 @@ import crazypants.enderio.ModObject;
 
 public class ItemFrankenSkull extends Item {
 
-  private final IIcon[] icons;  
+  private final IIcon[] icons;
 
   public static ItemFrankenSkull create() {
     ItemFrankenSkull alloy = new ItemFrankenSkull();
@@ -28,7 +28,7 @@ public class ItemFrankenSkull extends Item {
     setHasSubtypes(true);
     setMaxDamage(0);
     setCreativeTab(EnderIOTab.tabEnderIO);
-    setUnlocalizedName(ModObject.itemFrankenSkull.unlocalisedName);    
+    setUnlocalizedName(ModObject.itemFrankenSkull.unlocalisedName);
     icons = new IIcon[FrankenSkull.values().length];
   }
 
@@ -37,26 +37,29 @@ public class ItemFrankenSkull extends Item {
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public IIcon getIconFromDamage(int damage) {
     damage = MathHelper.clamp_int(damage, 0, icons.length - 1);
     return icons[damage];
   }
 
   @Override
-  public void registerIcons(IIconRegister IIconRegister) {    
+  @SideOnly(Side.CLIENT)
+  public void registerIcons(IIconRegister IIconRegister) {
     for (int i = 0; i < icons.length; i++) {
       icons[i] = IIconRegister.registerIcon(FrankenSkull.values()[i].iconKey);
-    }    
+    }
   }
 
   @Override
   public String getUnlocalizedName(ItemStack par1ItemStack) {
-    int i = MathHelper.clamp_int(par1ItemStack.getItemDamage(), 0, FrankenSkull.values().length - 1);    
-    return FrankenSkull.values()[i].unlocalisedName;    
+    int i = MathHelper.clamp_int(par1ItemStack.getItemDamage(), 0, FrankenSkull.values().length - 1);
+    return FrankenSkull.values()[i].unlocalisedName;
   }
 
   @Override
   @SuppressWarnings({ "rawtypes", "unchecked" })
+  @SideOnly(Side.CLIENT)
   public void getSubItems(Item par1, CreativeTabs par2CreativeTabs, List par3List) {
     for (int j = 0; j < FrankenSkull.values().length; ++j) {
       par3List.add(new ItemStack(par1, 1, j));
@@ -66,10 +69,10 @@ public class ItemFrankenSkull extends Item {
   @Override
   @SideOnly(Side.CLIENT)
   public boolean hasEffect(ItemStack par1ItemStack, int pass) {
-    int meta = MathHelper.clamp_int(par1ItemStack.getItemDamage(), 0, FrankenSkull.values().length - 1); 
+    int meta = MathHelper.clamp_int(par1ItemStack.getItemDamage(), 0, FrankenSkull.values().length - 1);
     return FrankenSkull.values()[meta].isAnimated;
   }
-  
-  
+
+
 
 }

--- a/src/main/java/crazypants/enderio/material/ItemFusedQuartz.java
+++ b/src/main/java/crazypants/enderio/material/ItemFusedQuartz.java
@@ -30,6 +30,7 @@ public class ItemFusedQuartz extends ItemBlockWithMetadata {
 
   @Override
   @SuppressWarnings({ "rawtypes", "unchecked" })
+  @SideOnly(Side.CLIENT)
   public void getSubItems(Item par1, CreativeTabs par2CreativeTabs, List par3List) {
     for (int j = 0; j < BlockFusedQuartz.Type.values().length; ++j) {
       par3List.add(new ItemStack(par1, 1, j));
@@ -48,6 +49,6 @@ public class ItemFusedQuartz extends ItemBlockWithMetadata {
       par3List.add(Lang.localize("lightEmitter"));
     }
   }
-  
-  
+
+
 }

--- a/src/main/java/crazypants/enderio/material/ItemFusedQuartzFrame.java
+++ b/src/main/java/crazypants/enderio/material/ItemFusedQuartzFrame.java
@@ -37,14 +37,16 @@ public class ItemFusedQuartzFrame extends Item {
     GameRegistry.registerItem(this, ModObject.itemFusedQuartzFrame.unlocalisedName);
     MachineRecipeRegistry.instance.registerRecipe(ModObject.blockPainter.unlocalisedName, new FramePainterRecipe(this));
   }
-  
+
   @SuppressWarnings({ "unchecked", "rawtypes" })
   @Override
+  @SideOnly(Side.CLIENT)
   public void getSubItems(Item item, CreativeTabs p_150895_2_, List list) {
     list.add(PainterUtil.applyDefaultPaintedState(new ItemStack(item)));
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public void registerIcons(IIconRegister IIconRegister) {
   }
 
@@ -97,6 +99,6 @@ public class ItemFusedQuartzFrame extends Item {
     public boolean isValidTarget(ItemStack target) {
       return target != null && target.getItem() == i;
     }
-    
+
   }
 }

--- a/src/main/java/crazypants/enderio/material/ItemMachinePart.java
+++ b/src/main/java/crazypants/enderio/material/ItemMachinePart.java
@@ -9,6 +9,8 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.IIcon;
 import net.minecraft.util.MathHelper;
 import cpw.mods.fml.common.registry.GameRegistry;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.EnderIOTab;
 import crazypants.enderio.ModObject;
 
@@ -36,12 +38,14 @@ public class ItemMachinePart extends Item {
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public IIcon getIconFromDamage(int damage) {
     damage = MathHelper.clamp_int(damage, 0, MachinePart.values().length - 1);
     return icons[damage];
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public void registerIcons(IIconRegister IIconRegister) {
     int numParts = MachinePart.values().length;
     for (int i = 0; i < numParts; i++) {
@@ -57,6 +61,7 @@ public class ItemMachinePart extends Item {
 
   @Override
   @SuppressWarnings({ "rawtypes", "unchecked" })
+  @SideOnly(Side.CLIENT)
   public void getSubItems(Item par1, CreativeTabs par2CreativeTabs, List par3List) {
     for (int j = 0; j < MachinePart.values().length; ++j) {
       par3List.add(new ItemStack(par1, 1, j));

--- a/src/main/java/crazypants/enderio/material/ItemMaterial.java
+++ b/src/main/java/crazypants/enderio/material/ItemMaterial.java
@@ -9,6 +9,8 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.IIcon;
 import net.minecraft.util.MathHelper;
 import cpw.mods.fml.common.registry.GameRegistry;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.EnderIOTab;
 import crazypants.enderio.ModObject;
 
@@ -36,12 +38,14 @@ public class ItemMaterial extends Item {
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public IIcon getIconFromDamage(int damage) {
     damage = MathHelper.clamp_int(damage, 0, Material.values().length - 1);
     return icons[damage];
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public void registerIcons(IIconRegister IIconRegister) {
     int numParts = Material.values().length;
     for (int i = 0; i < numParts; i++) {
@@ -57,6 +61,7 @@ public class ItemMaterial extends Item {
 
   @Override
   @SuppressWarnings({ "rawtypes", "unchecked" })
+  @SideOnly(Side.CLIENT)
   public void getSubItems(Item par1, CreativeTabs par2CreativeTabs, List par3List) {
     for (int j = 0; j < Material.values().length; ++j) {
       par3List.add(new ItemStack(par1, 1, j));
@@ -64,6 +69,7 @@ public class ItemMaterial extends Item {
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public boolean hasEffect(ItemStack par1ItemStack, int pass) {
     if(par1ItemStack == null) {
       return false;

--- a/src/main/java/crazypants/enderio/material/ItemPowderIngot.java
+++ b/src/main/java/crazypants/enderio/material/ItemPowderIngot.java
@@ -9,6 +9,8 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.IIcon;
 import net.minecraft.util.MathHelper;
 import cpw.mods.fml.common.registry.GameRegistry;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.EnderIOTab;
 import crazypants.enderio.ModObject;
 
@@ -36,12 +38,14 @@ public class ItemPowderIngot extends Item {
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public IIcon getIconFromDamage(int damage) {
     damage = MathHelper.clamp_int(damage, 0, PowderIngot.values().length - 1);
     return icons[damage];
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public void registerIcons(IIconRegister IIconRegister) {
     int numParts = PowderIngot.values().length;
     for (int i = 0; i < numParts; i++) {
@@ -57,6 +61,7 @@ public class ItemPowderIngot extends Item {
 
   @Override
   @SuppressWarnings({ "rawtypes", "unchecked" })
+  @SideOnly(Side.CLIENT)
   public void getSubItems(Item par1, CreativeTabs par2CreativeTabs, List par3List) {
     for (int j = 0; j < PowderIngot.values().length; ++j) {
       if(PowderIngot.values()[j].isDependancyMet()) {

--- a/src/main/java/crazypants/enderio/teleport/BlockTravelAnchor.java
+++ b/src/main/java/crazypants/enderio/teleport/BlockTravelAnchor.java
@@ -1,7 +1,5 @@
 package crazypants.enderio.teleport;
 
-import java.util.Random;
-
 import net.minecraft.block.Block;
 import net.minecraft.block.ITileEntityProvider;
 import net.minecraft.client.renderer.texture.IIconRegister;
@@ -14,6 +12,7 @@ import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
+import net.minecraftforge.common.UsernameCache;
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.network.IGuiHandler;
 import cpw.mods.fml.relauncher.Side;
@@ -38,7 +37,6 @@ import crazypants.enderio.teleport.packet.PacketOpenAuthGui;
 import crazypants.enderio.teleport.packet.PacketTravelEvent;
 import crazypants.util.IFacade;
 import crazypants.util.Lang;
-import net.minecraftforge.common.UsernameCache;
 
 public class BlockTravelAnchor extends BlockEio implements IGuiHandler, ITileEntityProvider, IResourceTooltipProvider, IFacade {
 
@@ -80,6 +78,7 @@ public class BlockTravelAnchor extends BlockEio implements IGuiHandler, ITileEnt
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public void registerBlockIcons(IIconRegister iIconRegister) {
     super.registerBlockIcons(iIconRegister);
     highlightOverlayIcon = iIconRegister.registerIcon("enderio:blockTravelAnchorHighlight");
@@ -87,6 +86,7 @@ public class BlockTravelAnchor extends BlockEio implements IGuiHandler, ITileEnt
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public IIcon getIcon(IBlockAccess world, int x, int y, int z, int blockSide) {
     TileEntity te = world.getTileEntity(x, y, z);
     if(te instanceof TileTravelAnchor) {
@@ -117,7 +117,7 @@ public class BlockTravelAnchor extends BlockEio implements IGuiHandler, ITileEnt
       }
     }
   }
-  
+
   @Override
   public boolean openGui(World world, int x, int y, int z, EntityPlayer entityPlayer, int side) {
     TileEntity te = world.getTileEntity(x, y, z);

--- a/src/main/java/crazypants/enderio/teleport/ItemTravelStaff.java
+++ b/src/main/java/crazypants/enderio/teleport/ItemTravelStaff.java
@@ -156,8 +156,9 @@ public class ItemTravelStaff extends ItemEnergyContainer implements IItemOfTrave
   public boolean isActive(EntityPlayer ep, ItemStack equipped) {
     return isEquipped(ep);
   }
-  
+
   @Override
+  @SideOnly(Side.CLIENT)
   public boolean isFull3D() {
     return true;
   }

--- a/src/main/java/crazypants/enderio/teleport/TravelEntitySpecialRenderer.java
+++ b/src/main/java/crazypants/enderio/teleport/TravelEntitySpecialRenderer.java
@@ -16,6 +16,8 @@ import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL12;
 import org.lwjgl.opengl.GL14;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.EnderIO;
 import crazypants.render.BoundingBox;
 import crazypants.render.CubeRenderer;
@@ -26,6 +28,7 @@ import crazypants.vecmath.Vector3d;
 import crazypants.vecmath.Vector3f;
 import crazypants.vecmath.Vector4f;
 
+@SideOnly(Side.CLIENT)
 public class TravelEntitySpecialRenderer extends TileEntitySpecialRenderer {
 
   private final Vector4f selectedColor;


### PR DESCRIPTION
* Added @SideOnly(Side.CLIENT) to methods that override methods that are
@SideOnly(Side.CLIENT).
* Added @SideOnly(Side.CLIENT) to classes that extend classes that are
@SideOnly(Side.CLIENT)
* Added @SideOnly(Side.CLIENT) to ClientProxy class

Note: These SideOnlys are useful because they make it clear for a programmer which methods he cannot call from server-side code. They cannot be used because the jvm doesn't like it at all to execute a method/class that overrides/extends a non-existing methods/class.

This change is harmless. If any of the newly annotated methods would have been called server-side, the game would have crashed hard in the past, too.