### PR TITLE
Prevent Non-Active blood magic tools being used

### DIFF
--- a/src/main/java/crazypants/enderio/machine/farm/TileFarmStation.java
+++ b/src/main/java/crazypants/enderio/machine/farm/TileFarmStation.java
@@ -56,12 +56,17 @@ public class TileFarmStation extends AbstractPoweredTaskEntity {
       if (item == null) {
         return false;
       }
-      return match(item) && !isBrokenTinkerTool(item);
+      return match(item) && !isBrokenTinkerTool(item) && isActive(item);
     }
 
     private boolean isBrokenTinkerTool(ItemStack item)
     {
       return item.hasTagCompound() && item.getTagCompound().hasKey("InfiTool") && item.getTagCompound().getCompoundTag("InfiTool").getBoolean("Broken");
+    }
+
+    private boolean isActive(ItemStack item)
+    {
+      return !item.hasTagCompound() || !item.getTagCompound().hasKey("isActive", 1) || item.getTagCompound().getBoolean("isActive");
     }
 
     abstract boolean match(ItemStack item);


### PR DESCRIPTION
It's not completely accurate as it's feasible someone else has an axe
with a boolean tag "isActive" - but I think it's likely the station
shouldn't use those either