### PR TITLE
removed duplicate code, simplified conduit network tick handling, ...

### DIFF
--- a/src/main/java/crazypants/enderio/conduit/AbstractConduit.java
+++ b/src/main/java/crazypants/enderio/conduit/AbstractConduit.java
@@ -437,9 +437,6 @@ public abstract class AbstractConduit implements IConduit {
             bundle.getEntity().getBlockType());
       }
     }
-    if(getNetwork() != null) {
-      getNetwork().onUpdateEntity(this);
-    }
   }
 
   @Override

--- a/src/main/java/crazypants/enderio/conduit/AbstractConduitNetwork.java
+++ b/src/main/java/crazypants/enderio/conduit/AbstractConduitNetwork.java
@@ -12,10 +12,12 @@ public abstract class AbstractConduitNetwork<T extends IConduit, I extends T> {
 
   protected final List<I> conduits = new ArrayList<I>();
 
-  protected Class<I> implClass;
+  protected final Class<I> implClass;
+  protected final Class<T> baseConduitClass;
 
-  protected AbstractConduitNetwork(Class<I> implClass) {
+  protected AbstractConduitNetwork(Class<I> implClass, Class<T> baseConduitClass) {
     this.implClass = implClass;
+    this.baseConduitClass = baseConduitClass;
   }
 
   public void init(IConduitBundle tile, Collection<I> connections, World world) {
@@ -35,7 +37,9 @@ public abstract class AbstractConduitNetwork<T extends IConduit, I extends T> {
     notifyNetworkOfUpdate();
   }
 
-  public abstract Class<T> getBaseConduitType();
+  public final Class<T> getBaseConduitType() {
+    return baseConduitClass;
+  }
 
   protected void setNetwork(World world, IConduitBundle tile) {
 
@@ -58,6 +62,9 @@ public abstract class AbstractConduitNetwork<T extends IConduit, I extends T> {
 
   public void addConduit(I con) {
     if(!conduits.contains(con)) {
+      if(conduits.isEmpty()) {
+        ConduitNetworkTickHandler.instance.registerNetwork(this);
+      }
       conduits.add(con);
     }
   }
@@ -67,6 +74,7 @@ public abstract class AbstractConduitNetwork<T extends IConduit, I extends T> {
       con.setNetwork(null);
     }
     conduits.clear();
+    ConduitNetworkTickHandler.instance.unregisterNetwork(this);
   }
 
   public List<I> getConduits() {
@@ -90,7 +98,6 @@ public abstract class AbstractConduitNetwork<T extends IConduit, I extends T> {
     return "AbstractConduitNetwork [conduits=" + sb.toString() + "]";
   }
 
-  public void onUpdateEntity(IConduit conduit) {
+  public void doNetworkTick() {
   }
-
 }

--- a/src/main/java/crazypants/enderio/conduit/ConduitNetworkTickHandler.java
+++ b/src/main/java/crazypants/enderio/conduit/ConduitNetworkTickHandler.java
@@ -1,6 +1,7 @@
 package crazypants.enderio.conduit;
 
 import java.util.ArrayList;
+import java.util.IdentityHashMap;
 import java.util.List;
 
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
@@ -19,12 +20,23 @@ public class ConduitNetworkTickHandler {
 
   private final List<TickListener> listeners = new ArrayList<TickListener>();
 
+  private final IdentityHashMap<AbstractConduitNetwork<?,?>, Boolean> networks =
+          new IdentityHashMap<AbstractConduitNetwork<?, ?>, Boolean>();
+
   public void addListener(TickListener listener) {
     listeners.add(listener);
   }
 
   public void removeListener(TickListener listener) {
     listeners.remove(listener);
+  }
+
+  public void registerNetwork(AbstractConduitNetwork<?,?> cn) {
+    networks.put(cn, Boolean.TRUE);
+  }
+
+  public void unregisterNetwork(AbstractConduitNetwork<?,?> cn) {
+    networks.remove(cn);
   }
 
   @SubscribeEvent
@@ -47,6 +59,9 @@ public class ConduitNetworkTickHandler {
       h.tickEnd(event);
     }
     listeners.clear();
+    for(AbstractConduitNetwork<?,?> cn : networks.keySet()) {
+      cn.doNetworkTick();
+    }
   }
 
 }

--- a/src/main/java/crazypants/enderio/conduit/gas/AbstractGasTankConduitNetwork.java
+++ b/src/main/java/crazypants/enderio/conduit/gas/AbstractGasTankConduitNetwork.java
@@ -8,16 +8,11 @@ public class AbstractGasTankConduitNetwork<T extends AbstractGasTankConduit> ext
   protected GasStack gasType;
 
   protected AbstractGasTankConduitNetwork(Class<T> cl) {
-    super(cl);
+    super(cl, IGasConduit.class);
   }
 
   public GasStack getGasType() {
     return gasType;
-  }
-
-  @Override
-  public Class<IGasConduit> getBaseConduitType() {
-    return IGasConduit.class;
   }
 
   @Override

--- a/src/main/java/crazypants/enderio/conduit/gas/GasConduitNetwork.java
+++ b/src/main/java/crazypants/enderio/conduit/gas/GasConduitNetwork.java
@@ -9,9 +9,6 @@ import mekanism.api.gas.IGasHandler;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
-import cpw.mods.fml.common.gameevent.TickEvent.ServerTickEvent;
-import crazypants.enderio.conduit.ConduitNetworkTickHandler;
-import crazypants.enderio.conduit.ConduitNetworkTickHandler.TickListener;
 import crazypants.enderio.conduit.IConduit;
 import crazypants.util.BlockCoord;
 
@@ -29,17 +26,8 @@ public class GasConduitNetwork extends AbstractGasTankConduitNetwork<GasConduit>
 
   private int lastSyncedVolume = -1;
 
-  private long timeAtLastApply;
-
-  private final InnerTickHandler tickHandler = new InnerTickHandler();
-
   public GasConduitNetwork() {
     super(GasConduit.class);
-  }
-
-  @Override
-  public Class<IGasConduit> getBaseConduitType() {
-    return IGasConduit.class;
   }
 
   @Override
@@ -97,24 +85,7 @@ public class GasConduitNetwork extends AbstractGasTankConduitNetwork<GasConduit>
   }
 
   @Override
-  public void onUpdateEntity(IConduit conduit) {
-    World world = conduit.getBundle().getEntity().getWorldObj();
-    if(world == null) {
-      return;
-    }
-    if(world.isRemote) {
-      return;
-    }
-
-    long curTime = world.getTotalWorldTime();
-    if(curTime > 0 && curTime != timeAtLastApply) {
-      timeAtLastApply = curTime;
-      ConduitNetworkTickHandler.instance.addListener(tickHandler);
-    }
-
-  }
-
-  private void doTick() {
+  public void doNetworkTick() {
     if(gasType == null || outputs.isEmpty() || !tank.containsValidGas() || tank.isEmpty()) {
       updateActiveState();
       return;
@@ -292,18 +263,6 @@ public class GasConduitNetwork extends AbstractGasTankConduitNetwork<GasConduit>
     }
     setConduitVolumes();
     lastSyncedVolume = tank.getStored();
-  }
-
-  private class InnerTickHandler implements TickListener {
-
-    @Override
-    public void tickStart(ServerTickEvent evt) {
-    }
-
-    @Override
-    public void tickEnd(ServerTickEvent evt) {
-      doTick();
-    }
   }
 
 }

--- a/src/main/java/crazypants/enderio/conduit/item/NetworkedInventory.java
+++ b/src/main/java/crazypants/enderio/conduit/item/NetworkedInventory.java
@@ -91,7 +91,7 @@ public class NetworkedInventory {
     return con.getOutputPriority(conDir);
   }
 
-  public void onTick(long tick) {
+  public void onTick() {
     if(tickDeficit > 0 || !canExtract() || !con.isExtractionRedstoneConditionMet(conDir)) {
       //do nothing     
     } else {

--- a/src/main/java/crazypants/enderio/conduit/liquid/AbstractTankConduitNetwork.java
+++ b/src/main/java/crazypants/enderio/conduit/liquid/AbstractTankConduitNetwork.java
@@ -9,16 +9,11 @@ public class AbstractTankConduitNetwork<T extends AbstractTankConduit> extends A
   protected boolean fluidTypeLocked = false;
 
   protected AbstractTankConduitNetwork(Class<T> cl) {
-    super(cl);
+    super(cl, ILiquidConduit.class);
   }
 
   public FluidStack getFluidType() {
     return liquidType;
-  }
-
-  @Override
-  public Class<ILiquidConduit> getBaseConduitType() {
-    return ILiquidConduit.class;
   }
 
   @Override

--- a/src/main/java/crazypants/enderio/conduit/liquid/EnderLiquidConduitNetwork.java
+++ b/src/main/java/crazypants/enderio/conduit/liquid/EnderLiquidConduitNetwork.java
@@ -29,12 +29,7 @@ public class EnderLiquidConduitNetwork extends AbstractConduitNetwork<ILiquidCon
   boolean filling;
 
   public EnderLiquidConduitNetwork() {
-    super(EnderLiquidConduit.class);
-  }
-
-  @Override
-  public Class<ILiquidConduit> getBaseConduitType() {
-    return ILiquidConduit.class;
+    super(EnderLiquidConduit.class, ILiquidConduit.class);
   }
 
   public void connectionChanged(EnderLiquidConduit con, ForgeDirection conDir) {

--- a/src/main/java/crazypants/enderio/conduit/me/MEConduitNetwork.java
+++ b/src/main/java/crazypants/enderio/conduit/me/MEConduitNetwork.java
@@ -5,17 +5,7 @@ import crazypants.enderio.conduit.AbstractConduitNetwork;
 public class MEConduitNetwork extends AbstractConduitNetwork<IMEConduit, IMEConduit> {
 
   public MEConduitNetwork() {
-    super(IMEConduit.class);
+    super(IMEConduit.class, IMEConduit.class);
   }
 
-  @Override
-  public Class<IMEConduit> getBaseConduitType() {
-    return IMEConduit.class;
-  }
-  
-  @Override
-  public void addConduit(IMEConduit con) {
-    // TODO Auto-generated method stub
-    super.addConduit(con);
-  }
 }

--- a/src/main/java/crazypants/enderio/conduit/power/NetworkPowerManager.java
+++ b/src/main/java/crazypants/enderio/conduit/power/NetworkPowerManager.java
@@ -11,10 +11,7 @@ import java.util.Set;
 import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
-import cpw.mods.fml.common.gameevent.TickEvent.ServerTickEvent;
 import crazypants.enderio.Log;
-import crazypants.enderio.conduit.ConduitNetworkTickHandler;
-import crazypants.enderio.conduit.ConduitNetworkTickHandler.TickListener;
 import crazypants.enderio.conduit.ConnectionMode;
 import crazypants.enderio.conduit.power.PowerConduitNetwork.ReceptorEntry;
 import crazypants.enderio.config.Config;
@@ -23,11 +20,10 @@ import crazypants.enderio.power.IPowerStorage;
 
 public class NetworkPowerManager {
 
-  private PowerConduitNetwork network;
+  private final PowerConduitNetwork network;
 
   int maxEnergyStored;
   int energyStored;
-  private int reserved;
 
   private int updateRenderTicks = 10;
   private int inactiveTicks = 100;
@@ -41,11 +37,9 @@ public class NetworkPowerManager {
 
   private final Map<IPowerConduit, PowerTracker> powerTrackers = new HashMap<IPowerConduit, PowerTracker>();
 
-  private PowerTracker networkPowerTracker = new PowerTracker();
+  private final PowerTracker networkPowerTracker = new PowerTracker();
 
   private final CapBankSupply capSupply = new CapBankSupply();
-
-  private InnerTickHandler applyPowerCallback = new InnerTickHandler();
 
   public NetworkPowerManager(PowerConduitNetwork netowrk, World world) {
     network = netowrk;
@@ -113,8 +107,11 @@ public class NetworkPowerManager {
   }
 
   public void applyRecievedPower() {
-    //want to do this after all conduits have updated so all connections have been checked etc
-    ConduitNetworkTickHandler.instance.addListener(applyPowerCallback);
+    try {
+      doApplyRecievedPower();
+    } catch (Exception e) {
+      Log.warn("NetworkPowerManager: Exception thrown when updating power network " + e);
+    }
   }
 
   public void doApplyRecievedPower() {
@@ -525,22 +522,6 @@ public class NetworkPowerManager {
 
     }
 
-  }
-
-  private class InnerTickHandler implements TickListener {
-
-    @Override
-    public void tickStart(ServerTickEvent evt) {
-    }
-
-    @Override
-    public void tickEnd(ServerTickEvent evt) {
-      try {
-        doApplyRecievedPower();
-      } catch (Exception e) {
-        Log.warn("NetworkPowerManager: Exception thrown when updating power network " + e);
-      }
-    }
   }
 
 }

--- a/src/main/java/crazypants/enderio/conduit/power/PowerConduitNetwork.java
+++ b/src/main/java/crazypants/enderio/conduit/power/PowerConduitNetwork.java
@@ -11,7 +11,6 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 import crazypants.enderio.conduit.AbstractConduitNetwork;
-import crazypants.enderio.conduit.IConduit;
 import crazypants.enderio.conduit.IConduitBundle;
 import crazypants.enderio.power.IPowerInterface;
 import crazypants.util.BlockCoord;
@@ -22,12 +21,10 @@ public class PowerConduitNetwork extends AbstractConduitNetwork<IPowerConduit, I
 
   NetworkPowerManager powerManager;
 
-  private Map<ReceptorKey, ReceptorEntry> powerReceptors = new HashMap<ReceptorKey, ReceptorEntry>();
-
-  private long timeAtLastApply = -1;
+  private final Map<ReceptorKey, ReceptorEntry> powerReceptors = new HashMap<ReceptorKey, ReceptorEntry>();
 
   public PowerConduitNetwork() {
-    super(IPowerConduit.class);
+    super(IPowerConduit.class, IPowerConduit.class);
   }
 
   @Override
@@ -68,11 +65,6 @@ public class PowerConduitNetwork extends AbstractConduitNetwork<IPowerConduit, I
     }
   }
 
-  @Override
-  public Class<IPowerConduit> getBaseConduitType() {
-    return IPowerConduit.class;
-  }
-
   public void powerReceptorAdded(IPowerConduit powerConduit, ForgeDirection direction, int x, int y, int z, IPowerInterface powerReceptor) {
     if(powerReceptor == null) {
       return;
@@ -108,19 +100,8 @@ public class PowerConduitNetwork extends AbstractConduitNetwork<IPowerConduit, I
   }
 
   @Override
-  public void onUpdateEntity(IConduit conduit) {
-    World world = conduit.getBundle().getEntity().getWorldObj();
-    if(world == null) {
-      return;
-    }
-    if(world.isRemote) {
-      return;
-    }
-    long curTime = world.getTotalWorldTime();
-    if(curTime != timeAtLastApply) {
-      timeAtLastApply = curTime;
-      powerManager.applyRecievedPower();
-    }
+  public void doNetworkTick() {
+    powerManager.applyRecievedPower();
   }
 
   public static class ReceptorEntry {

--- a/src/main/java/crazypants/enderio/conduit/redstone/RedstoneConduitNetwork.java
+++ b/src/main/java/crazypants/enderio/conduit/redstone/RedstoneConduitNetwork.java
@@ -22,12 +22,7 @@ public class RedstoneConduitNetwork extends AbstractConduitNetwork<IRedstoneCond
   private boolean networkEnabled = true;
 
   public RedstoneConduitNetwork() {
-    super(IRedstoneConduit.class);
-  }
-
-  @Override
-  public Class<IRedstoneConduit> getBaseConduitType() {
-    return IRedstoneConduit.class;
+    super(IRedstoneConduit.class, IRedstoneConduit.class);
   }
 
   @Override
@@ -144,9 +139,7 @@ public class RedstoneConduitNetwork extends AbstractConduitNetwork<IRedstoneCond
     StringBuilder sb = new StringBuilder();
     for (IRedstoneConduit con : conduits) {
       TileEntity te = con.getBundle().getEntity();
-      sb.append("<");
-      sb.append(te.xCoord + "," + te.yCoord + "," + te.zCoord);
-      sb.append(">");
+      sb.append("<").append(te.xCoord).append(",").append(te.yCoord).append(",").append(te.zCoord).append(">");
     }
     return sb.toString();
   }


### PR DESCRIPTION
...removed dead code, and deal with #1954 while we are here

Basic idea behind the change:
1: Every conduit will create or join a conduit network.
2a: Each conduit network updateEntity method checked if the network was already scheduled for the tick handler this tick.
3a: The tick handler would then call the conduit network's tick function.

So instead of doing the check in 2a from every tile entity:
2b: Conduit network register them self with the tick handler once they are get their first conduit and, and unregistered when they are destroyed
3b: The tick handler calls each conduit network's tick function