### PR TITLE
made despawn protection time configurable, set default to the intended 2 minutes

### DIFF
--- a/src/main/java/crazypants/enderio/config/Config.java
+++ b/src/main/java/crazypants/enderio/config/Config.java
@@ -316,6 +316,7 @@ public final class Config {
   public static int poweredSpawnerLevelTwoPowerPerTickRF = 500;
   public static int poweredSpawnerLevelThreePowerPerTickRF = 1500;
   public static int poweredSpawnerMaxPlayerDistance = 0;
+  public static int poweredSpawnerDespawnTimeSeconds = 120;
   public static boolean poweredSpawnerUseVanillaSpawChecks = false;
   public static double brokenSpawnerDropChance = 1;
   public static String[] brokenSpawnerToolBlacklist = new String[] {
@@ -1000,6 +1001,8 @@ public final class Config {
         "RF per tick for a level 3 spawner").getInt(poweredSpawnerLevelThreePowerPerTickRF);
     poweredSpawnerMaxPlayerDistance = config.get(sectionSpawner.name, "poweredSpawnerMaxPlayerDistance", poweredSpawnerMaxPlayerDistance,
         "Max distance of the closest player for the spawner to be active. A zero value will remove the player check").getInt(poweredSpawnerMaxPlayerDistance);
+    poweredSpawnerDespawnTimeSeconds = config.get(sectionSpawner.name, "poweredSpawnerDespawnTimeSeconds" , poweredSpawnerDespawnTimeSeconds,
+        "Number of seconds in which spawned entities are protected from despawning").getInt(poweredSpawnerDespawnTimeSeconds);
     poweredSpawnerUseVanillaSpawChecks = config.get(sectionSpawner.name, "poweredSpawnerUseVanillaSpawChecks", poweredSpawnerUseVanillaSpawChecks,
         "If true, regular spawn checks such as lighting level and dimension will be made before spawning mobs").getBoolean(poweredSpawnerUseVanillaSpawChecks);
     brokenSpawnerDropChance = (float) config.get(sectionSpawner.name, "brokenSpawnerDropChance", brokenSpawnerDropChance,

--- a/src/main/java/crazypants/enderio/machine/spawner/BlockPoweredSpawner.java
+++ b/src/main/java/crazypants/enderio/machine/spawner/BlockPoweredSpawner.java
@@ -193,7 +193,7 @@ public class BlockPoweredSpawner extends AbstractMachineBlock<TilePoweredSpawner
 
     long spawnTime = ent.getEntityData().getLong(KEY_SPAWNED_BY_POWERED_SPAWNER);
     long livedFor = livingUpdate.entity.worldObj.getTotalWorldTime() - spawnTime;
-    if(livedFor > 1200) { //after two minutes stop forcing it to be around 
+    if(livedFor > Config.poweredSpawnerDespawnTimeSeconds*20) {
       try {
         fieldpersistenceRequired.setBoolean(livingUpdate.entityLiving, false);
         ent.getEntityData().removeTag(KEY_SPAWNED_BY_POWERED_SPAWNER);

--- a/src/main/java/crazypants/enderio/machine/spawner/TilePoweredSpawner.java
+++ b/src/main/java/crazypants/enderio/machine/spawner/TilePoweredSpawner.java
@@ -74,7 +74,7 @@ public class TilePoweredSpawner extends AbstractPoweredTaskEntity {
         return;
       }
       String name = logic.getEntityNameToSpawn();
-      if(name == NULL_ENTITY_NAME) {
+      if(NULL_ENTITY_NAME.equals(name)) {
         return;
       }
       ItemStack res = EnderIO.itemSoulVessel.createVesselWithEntityStub(logic.getEntityNameToSpawn());
@@ -378,7 +378,7 @@ public class TilePoweredSpawner extends AbstractPoweredTaskEntity {
 
     Entity createEntity(boolean forceAlive) {
       Entity ent = EntityList.createEntityByName(getEntityNameToSpawn(), getSpawnerWorld());     
-      if(forceAlive && MIN_PLAYER_DISTANCE <= 0 && ent instanceof EntityLiving) {
+      if(forceAlive && MIN_PLAYER_DISTANCE <= 0 && Config.poweredSpawnerDespawnTimeSeconds > 0 && ent instanceof EntityLiving) {
          ent.getEntityData().setLong(BlockPoweredSpawner.KEY_SPAWNED_BY_POWERED_SPAWNER, getSpawnerWorld().getTotalWorldTime());
         ((EntityLiving) ent).func_110163_bv();
       }


### PR DESCRIPTION
The comment mentioned 2 minutes (120*20) - but the code only used 1 minute (60*20).

This should make the powered spawner a bit more useful with blood magic scarifying ritual which deals damage slowly.