### PR TITLE
Deep copy ore dictionary list

### DIFF
--- a/src/main/java/crazypants/enderio/machine/recipe/OreDictionaryRecipeInput.java
+++ b/src/main/java/crazypants/enderio/machine/recipe/OreDictionaryRecipeInput.java
@@ -54,10 +54,12 @@ public class OreDictionaryRecipeInput extends RecipeInput {
     if(res == null || res.isEmpty()) {
       return null;
     }
-    for(ItemStack st : res) {
-      st.stackSize = getInput().stackSize;
+    ItemStack[] res2 = res.toArray(new ItemStack[res.size()]);
+    for(int i = 0; i < res.size(); ++i) {
+      res2[i] = res2[i].copy();
+      res2[i].stackSize = getInput().stackSize;
     }
-    return res.toArray(new ItemStack[res.size()]);
+    return res2;
   }
 
   @Override


### PR DESCRIPTION
prevents ore dictionary from being modified (this solves the bug due to enchanter ore-dictionary recipes where number != 1)  ex ttCore XP boost