### PR TITLE
#1745 Fix grinding ball handling

### DIFF
--- a/src/main/java/crazypants/enderio/machine/crusher/CrusherRecipeManager.java
+++ b/src/main/java/crazypants/enderio/machine/crusher/CrusherRecipeManager.java
@@ -128,16 +128,19 @@ public class CrusherRecipeManager {
   }
 
   public void addCustomRecipes(String xmlDef) {
+    GrindingBallTagHandler th = new GrindingBallTagHandler();
     RecipeConfig config;
     try {
-      config = RecipeConfigParser.parse(xmlDef, new GrindingBallTagHandler());
+      config = RecipeConfigParser.parse(xmlDef, th);
     } catch (Exception e) {
       Log.error("Error parsing custom xml");
       return;
     }
 
+    balls.addAll(th.balls.values());
+    ballExcludes.addAll(th.excludes);
     if(config == null) {
-      Log.error("Could process custom XML");
+      Log.error("Could not process custom XML");
       return;
     }
     processConfig(config);


### PR DESCRIPTION
Commit 35324eaab0815158f5151bca30ec82760b7acbf1 was not quite solving #1745. The grinding balls and excludes actually have to be added to the respective lists in CrusherRecipeManager.

Also, fixed a small typo