### PR TITLE
Some fixes/optimizations for the TreeFarmer

### DIFF
--- a/src/main/java/crazypants/enderio/machine/farm/TileFarmStation.java
+++ b/src/main/java/crazypants/enderio/machine/farm/TileFarmStation.java
@@ -210,15 +210,16 @@ public class TileFarmStation extends AbstractPoweredTaskEntity {
 
   public void damageTool(ToolType type, Block blk, BlockCoord bc, int damage) {
 
+    ItemStack tool = getTool(type);
+    if(tool == null) {
+      return;
+    }
+
     float rand = worldObj.rand.nextFloat();
     if(rand >= Config.farmToolTakeDamageChance) {
       return;
     }
 
-    ItemStack tool = getTool(type);
-    if(tool == null) {
-      return;
-    }
     boolean canDamage = canDamage(tool);
     if(type == ToolType.AXE) {
       tool.getItem().onBlockDestroyed(tool, worldObj, blk, bc.x, bc.y, bc.z, farmerJoe);

--- a/src/main/java/crazypants/enderio/machine/farm/farmers/TreeFarmer.java
+++ b/src/main/java/crazypants/enderio/machine/farm/farmers/TreeFarmer.java
@@ -104,10 +104,13 @@ public class TreeFarmer implements IFarmerJoe {
   @Override
   public IHarvestResult harvestBlock(TileFarmStation farm, BlockCoord bc, Block block, int meta) {
 
-    HarvestResult res = new HarvestResult();
-    if(!farm.hasAxe()) {
-      return res;
+    boolean hasAxe = farm.hasAxe();
+
+    if(!hasAxe) {
+      return null;
     }
+
+    HarvestResult res = new HarvestResult();
     harvester.harvest(farm, this, bc, res);
     Collections.sort(res.harvestedBlocks, comp);
 
@@ -116,7 +119,7 @@ public class TreeFarmer implements IFarmerJoe {
     // avoid calling this in a loop
     boolean hasShears = farm.hasShears();
 
-    for (int i = 0; i < res.harvestedBlocks.size() && farm.hasAxe(); i++) {
+    for (int i = 0; i < res.harvestedBlocks.size() && hasAxe; i++) {
       BlockCoord coord = res.harvestedBlocks.get(i);
       Block blk = farm.getBlock(coord);
 
@@ -126,10 +129,10 @@ public class TreeFarmer implements IFarmerJoe {
       boolean wasWood = isWood(blk);
       
       if (blk instanceof IShearable && hasShears) {
-        drops = ((IShearable)blk).onSheared(null, farm.getWorldObj(), bc.x, bc.y, bc.z, 0);
+        drops = ((IShearable)blk).onSheared(null, farm.getWorldObj(), coord.x, coord.y, coord.z, 0);
         wasSheared = true;
       } else {
-        drops = blk.getDrops(farm.getWorldObj(), bc.x, bc.y, bc.z, farm.getBlockMeta(coord), farm.getAxeLootingValue());
+        drops = blk.getDrops(farm.getWorldObj(), coord.x, coord.y, coord.z, farm.getBlockMeta(coord), farm.getAxeLootingValue());
         wasAxed = true;
       }
       
@@ -152,15 +155,17 @@ public class TreeFarmer implements IFarmerJoe {
       farm.actionPerformed(wasWood || wasSheared);
       if(wasAxed) {
         farm.damageAxe(blk, coord);
+        hasAxe = farm.hasAxe();
       } else if (wasSheared) {
         farm.damageShears(blk, coord);
+        hasShears = farm.hasShears();
       }
       
       farm.getWorldObj().setBlockToAir(coord.x, coord.y, coord.z);
       actualHarvests.add(coord);
     }
     
-    if (!farm.hasAxe()) {
+    if (!hasAxe) {
       farm.setNotification(TileFarmStation.NOTIFICATION_NO_AXE);
     }
     


### PR DESCRIPTION
* Fix: Shears will stop shearing after being destroyed
* Optimization: Don't bother trying to do work if there is no axe or no
tree (harvestBlock() is allowed to return null...)
* Optimization: Changed hasAxe handling to the same as hasShears (if we
have an axe we'll keep it as long as we don't damage it)
* Optimization: In damageTool(), only roll the dice if there is a tool
to be damaged
* Fix: When asking a block for its drops, give it its own coordinates