### PR TITLE
Fix for Farming Station Upgrading

### DIFF
--- a/src/main/java/crazypants/enderio/machine/farm/TileFarmStation.java
+++ b/src/main/java/crazypants/enderio/machine/farm/TileFarmStation.java
@@ -646,10 +646,13 @@ public class TileFarmStation extends AbstractPoweredTaskEntity {
     }
     int slotLayoutVersion = nbtRoot.getInteger("slotLayoutVersion");
     if (slotLayoutVersion < 1) {
-      for (int i = 9; i >= 2; i--) {
-        inventory[i+1] = inventory[i];
+      for (int i = inventory.length - 2; i >= 2; i--) {
+        if (inventory[i+1] == null) {
+          // Should always be true, but better safe than deleting items
+          inventory[i+1] = inventory[i];
+          inventory[i] = null;
+        }
       }
-      inventory[2] = null;
     }
   }
 


### PR DESCRIPTION
* Farming station slot shifting had an off-by-one error that destroyed
installed capacitors
* Also added some sanity checks that would have prevented item loss

Fixes bug reported in comment of #2005